### PR TITLE
fix: specify encoding when saving HTML

### DIFF
--- a/crazy_functions/对话历史存档.py
+++ b/crazy_functions/对话历史存档.py
@@ -13,7 +13,7 @@ def write_chat_to_file(chatbot, history=None, file_name=None):
     os.makedirs('./gpt_log/', exist_ok=True)
     with open(f'./gpt_log/{file_name}', 'w', encoding='utf8') as f:
         from theme import advanced_css
-        f.write(f'<head><title>对话历史</title><style>{advanced_css}</style></head>')
+        f.write(f'<!DOCTYPE html><head><meta charset="utf-8"><title>对话历史</title><style>{advanced_css}</style></head>')
         for i, contents in enumerate(chatbot):
             for j, content in enumerate(contents):
                 try:    # 这个bug没找到触发条件，暂时先这样顶一下


### PR DESCRIPTION
解决导出的HTML在macOS中可能显示为乱码的问题。

（这里以我们川虎Chat导出的历史记录为例，不过应该差不多）

 |before：|after: |
|----|----|
| <img width="663" alt="image" src="https://user-images.githubusercontent.com/23137268/235687430-6899cca7-d9cc-4115-8c4f-7be3eb19f109.png">|<img width="663" alt="image" src="https://user-images.githubusercontent.com/23137268/235688123-da4cdd5b-0575-40cd-943b-9f3d1efd3f49.png">|
