### PR TITLE
feat:把原有的解析react替换成解析整个前端

### DIFF
--- a/crazy_functional.py
+++ b/crazy_functional.py
@@ -11,7 +11,7 @@ def get_crazy_functions():
     from crazy_functions.解析项目源代码 import 解析一个C项目
     from crazy_functions.解析项目源代码 import 解析一个Golang项目
     from crazy_functions.解析项目源代码 import 解析一个Java项目
-    from crazy_functions.解析项目源代码 import 解析一个Rect项目
+    from crazy_functions.解析项目源代码 import 解析一个前端项目
     from crazy_functions.高级功能函数模板 import 高阶功能模板函数
     from crazy_functions.代码重写为全英文_多线程 import 全项目切换英文
     from crazy_functions.Latex全文润色 import Latex英文润色
@@ -70,10 +70,10 @@ def get_crazy_functions():
             "AsButton": False,  # 加入下拉菜单中
             "Function": HotReload(解析一个Java项目)
         },
-        "解析整个React项目": {
+        "解析整个前端项目": {
             "Color": "stop",  # 按钮颜色
             "AsButton": False,  # 加入下拉菜单中
-            "Function": HotReload(解析一个Rect项目)
+            "Function": HotReload(解析一个前端项目)
         },
         "解析整个Lua项目": {
             "Color": "stop",    # 按钮颜色

--- a/crazy_functional.py
+++ b/crazy_functional.py
@@ -70,7 +70,7 @@ def get_crazy_functions():
             "AsButton": False,  # 加入下拉菜单中
             "Function": HotReload(解析一个Java项目)
         },
-        "解析整个前端项目": {
+        "解析整个前端项目（js,ts,css等）": {
             "Color": "stop",  # 按钮颜色
             "AsButton": False,  # 加入下拉菜单中
             "Function": HotReload(解析一个前端项目)

--- a/crazy_functions/解析项目源代码.py
+++ b/crazy_functions/解析项目源代码.py
@@ -183,7 +183,7 @@ def 解析一个Java项目(txt, llm_kwargs, plugin_kwargs, chatbot, history, sys
 
 
 @CatchException
-def 解析一个Rect项目(txt, llm_kwargs, plugin_kwargs, chatbot, history, system_prompt, web_port):
+def 解析一个前端项目(txt, llm_kwargs, plugin_kwargs, chatbot, history, system_prompt, web_port):
     history = []  # 清空历史，以免输入溢出
     import glob, os
     if os.path.exists(txt):
@@ -197,9 +197,15 @@ def 解析一个Rect项目(txt, llm_kwargs, plugin_kwargs, chatbot, history, sys
                     [f for f in glob.glob(f'{project_folder}/**/*.tsx', recursive=True)] + \
                     [f for f in glob.glob(f'{project_folder}/**/*.json', recursive=True)] + \
                     [f for f in glob.glob(f'{project_folder}/**/*.js', recursive=True)] + \
+                    [f for f in glob.glob(f'{project_folder}/**/*.vue', recursive=True)] + \
+                    [f for f in glob.glob(f'{project_folder}/**/*.less', recursive=True)] + \
+                    [f for f in glob.glob(f'{project_folder}/**/*.sass', recursive=True)] + \
+                    [f for f in glob.glob(f'{project_folder}/**/*.wxml', recursive=True)] + \
+                    [f for f in glob.glob(f'{project_folder}/**/*.wxss', recursive=True)] + \
+                    [f for f in glob.glob(f'{project_folder}/**/*.css', recursive=True)] + \
                     [f for f in glob.glob(f'{project_folder}/**/*.jsx', recursive=True)]
     if len(file_manifest) == 0:
-        report_execption(chatbot, history, a=f"解析项目: {txt}", b=f"找不到任何Rect文件: {txt}")
+        report_execption(chatbot, history, a=f"解析项目: {txt}", b=f"找不到任何前端相关文件: {txt}")
         yield from update_ui(chatbot=chatbot, history=history) # 刷新界面
         return
     yield from 解析源代码新(file_manifest, project_folder, llm_kwargs, plugin_kwargs, chatbot, history, system_prompt)

--- a/docs/self_analysis.md
+++ b/docs/self_analysis.md
@@ -157,7 +157,7 @@
 
 ## [22/31] 请对下面的程序文件做一个概述: H:\chatgpt_academic_resolve\crazy_functions\解析项目源代码.py
 
-这个程序文件实现了对一个源代码项目进行分析的功能。其中，函数`解析项目本身`、`解析一个Python项目`、`解析一个C项目的头文件`、`解析一个C项目`、`解析一个Java项目`和`解析一个Rect项目`分别用于解析不同类型的项目。函数`解析源代码新`实现了对每一个源代码文件的分析，并将分析结果汇总，同时还实现了分组和迭代处理，提高了效率。最后，函数`write_results_to_file`将所有分析结果写入文件。中间，还用到了`request_gpt_model_multi_threads_with_very_awesome_ui_and_high_efficiency`和`request_gpt_model_in_new_thread_with_ui_alive`来完成请求和响应，并用`update_ui`实时更新界面。
+这个程序文件实现了对一个源代码项目进行分析的功能。其中，函数`解析项目本身`、`解析一个Python项目`、`解析一个C项目的头文件`、`解析一个C项目`、`解析一个Java项目`和`解析前端项目`分别用于解析不同类型的项目。函数`解析源代码新`实现了对每一个源代码文件的分析，并将分析结果汇总，同时还实现了分组和迭代处理，提高了效率。最后，函数`write_results_to_file`将所有分析结果写入文件。中间，还用到了`request_gpt_model_multi_threads_with_very_awesome_ui_and_high_efficiency`和`request_gpt_model_in_new_thread_with_ui_alive`来完成请求和响应，并用`update_ui`实时更新界面。
 
 ## [23/31] 请对下面的程序文件做一个概述: H:\chatgpt_academic_resolve\crazy_functions\询问多个大语言模型.py
 


### PR DESCRIPTION
react在前端开发中属于其中一种框架，我在这次PR中加入常见的**前端开发后缀文件**,也同时支持了

<img width="809" alt="image" src="https://user-images.githubusercontent.com/16920092/235743994-4e086c20-b542-48bd-8e1e-acda96e9737f.png">

* css
* sass
* less
* vue
* 小程序

不仅仅只能解析react，大部分的前端项目都可以进行解析了。