### PR TITLE
fix: resolve keyerror 'serialized_input' for mac/windows platform

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-gradio==3.25.0
+gradio==3.26.0
 tiktoken>=0.3.3
 requests[socks]
 transformers

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-gradio==3.26.0
+gradio==3.28.3
 tiktoken>=0.3.3
 requests[socks]
 transformers


### PR DESCRIPTION
Resolve keyerror 'serialized_input' for mac/windows platform and `python3.9`, `python3.10`. `gradio==3.26.0` can fix this problem. #693 #692 

I got this error using `Win10 Python3.10` and method1 to run the project. I ran into the same problem when deploying docker on mac.