### PR TITLE
增加azure openai api的支持

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,6 +1,13 @@
 # [step 1]>> 例如： API_KEY = "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" （此key无效）
 API_KEY = "sk-此处填API密钥"    # 可同时填写多个API-KEY，用英文逗号分割，例如API_KEY = "sk-openaikey1,sk-openaikey2,fkxxxx-api2dkey1,fkxxxx-api2dkey2"
 
+#增加关于AZURE的配置信息， 可以在AZURE网页中找到
+AZURE_ENDPOINT = "https://你的api名称.openai.azure.com/"
+AZURE_API_KEY = "填入azure openai api的密钥"
+AZURE_API_VERSION = "填入api版本"
+AZURE_ENGINE = "填入ENGINE"
+
+
 # [step 2]>> 改为True应用代理，如果直接在海外服务器部署，此处不修改
 USE_PROXY = False
 if USE_PROXY:

--- a/request_llm/bridge_all.py
+++ b/request_llm/bridge_all.py
@@ -16,6 +16,9 @@ from toolbox import get_conf, trimmed_format_exc
 from .bridge_chatgpt import predict_no_ui_long_connection as chatgpt_noui
 from .bridge_chatgpt import predict as chatgpt_ui
 
+from .bridge_azure_test import predict_no_ui_long_connection as azure_noui
+from .bridge_azure_test import predict as azure_ui
+
 from .bridge_chatglm import predict_no_ui_long_connection as chatglm_noui
 from .bridge_chatglm import predict as chatglm_ui
 
@@ -91,6 +94,16 @@ model_info = {
         "max_token": 8192,
         "tokenizer": tokenizer_gpt4,
         "token_cnt": get_token_num_gpt4,
+    },
+
+    # azure openai
+    "azure-gpt35":{
+        "fn_with_ui": azure_ui,
+        "fn_without_ui": azure_noui,
+        "endpoint": get_conf("AZURE_ENDPOINT"),
+        "max_token": 4096,
+        "tokenizer": tokenizer_gpt35,
+        "token_cnt": get_token_num_gpt35,
     },
 
     # api_2d

--- a/request_llm/bridge_azure_test.py
+++ b/request_llm/bridge_azure_test.py
@@ -1,0 +1,241 @@
+"""
+    该文件中主要包含三个函数
+
+    不具备多线程能力的函数：
+    1. predict: 正常对话时使用，具备完备的交互功能，不可多线程
+
+    具备多线程调用能力的函数
+    2. predict_no_ui：高级实验性功能模块调用，不会实时显示在界面上，参数简单，可以多线程并行，方便实现复杂的功能逻辑
+    3. predict_no_ui_long_connection：在实验过程中发现调用predict_no_ui处理长文档时，和openai的连接容易断掉，这个函数用stream的方式解决这个问题，同样支持多线程
+"""
+
+import logging
+import traceback
+import importlib
+import openai
+import time
+
+
+# 读取config.py文件中关于AZURE OPENAI API的信息
+from toolbox import get_conf, update_ui, clip_history, trimmed_format_exc
+TIMEOUT_SECONDS, MAX_RETRY, AZURE_ENGINE, AZURE_ENDPOINT, AZURE_API_VERSION, AZURE_API_KEY = \
+    get_conf('TIMEOUT_SECONDS', 'MAX_RETRY',"AZURE_ENGINE","AZURE_ENDPOINT", "AZURE_API_VERSION", "AZURE_API_KEY")
+
+
+def get_full_error(chunk, stream_response):
+    """
+        获取完整的从Openai返回的报错
+    """
+    while True:
+        try:
+            chunk += next(stream_response)
+        except:
+            break
+    return chunk
+
+def predict(inputs, llm_kwargs, plugin_kwargs, chatbot, history=[], system_prompt='', stream = True, additional_fn=None):
+    """
+    发送至azure openai api，流式获取输出。
+    用于基础的对话功能。
+    inputs 是本次问询的输入
+    top_p, temperature是chatGPT的内部调优参数
+    history 是之前的对话列表（注意无论是inputs还是history，内容太长了都会触发token数量溢出的错误）
+    chatbot 为WebUI中显示的对话列表，修改它，然后yeild出去，可以直接修改对话界面内容
+    additional_fn代表点击的哪个按钮，按钮见functional.py
+    """
+    print(llm_kwargs["llm_model"])    
+
+    if additional_fn is not None:
+        import core_functional
+        importlib.reload(core_functional)    # 热更新prompt
+        core_functional = core_functional.get_core_functions()
+        if "PreProcess" in core_functional[additional_fn]: inputs = core_functional[additional_fn]["PreProcess"](inputs)  # 获取预处理函数（如果有的话）
+        inputs = core_functional[additional_fn]["Prefix"] + inputs + core_functional[additional_fn]["Suffix"]
+
+    raw_input = inputs
+    logging.info(f'[raw_input] {raw_input}')
+    chatbot.append((inputs, ""))
+    yield from update_ui(chatbot=chatbot, history=history, msg="等待响应") # 刷新界面
+
+    
+    payload = generate_azure_payload(inputs, llm_kwargs, history, system_prompt, stream)    
+        
+    history.append(inputs); history.append("")
+
+    retry = 0
+    while True:
+        try:            
+                
+            openai.api_type = "azure"            
+            openai.api_version = AZURE_API_VERSION
+            openai.api_base = AZURE_ENDPOINT
+            openai.api_key = AZURE_API_KEY
+            response = openai.ChatCompletion.create(timeout=TIMEOUT_SECONDS, **payload);break
+        
+        except:
+            retry += 1
+            chatbot[-1] = ((chatbot[-1][0], "获取response失败，重试中。。。"))
+            retry_msg = f"，正在重试 ({retry}/{MAX_RETRY}) ……" if MAX_RETRY > 0 else ""
+            yield from update_ui(chatbot=chatbot, history=history, msg="请求超时"+retry_msg) # 刷新界面
+            if retry > MAX_RETRY: raise TimeoutError
+            
+    gpt_replying_buffer = ""    
+    is_head_of_the_stream = True
+    if stream:
+
+        stream_response = response
+
+        while True:
+            try:
+                chunk = next(stream_response)
+                    
+            except StopIteration:                
+                from toolbox import regular_txt_to_markdown; tb_str = '```\n' + trimmed_format_exc() + '```'
+                chatbot[-1] = (chatbot[-1][0], f"[Local Message] 远程返回错误: \n\n{tb_str} \n\n{regular_txt_to_markdown(chunk)}")
+                yield from update_ui(chatbot=chatbot, history=history, msg="远程返回错误:" + chunk) # 刷新界面
+                return            
+            
+            if is_head_of_the_stream and (r'"object":"error"' not in chunk):
+                # 数据流的第一帧不携带content
+                is_head_of_the_stream = False; continue
+            
+            if chunk:
+                #print(chunk)
+                try:                     
+                    if "delta" in chunk["choices"][0]:
+                        if chunk["choices"][0]["finish_reason"] == "stop":
+                            logging.info(f'[response] {gpt_replying_buffer}')
+                            break
+                    status_text = f"finish_reason: {chunk['choices'][0]['finish_reason']}"    
+                    gpt_replying_buffer = gpt_replying_buffer + chunk["choices"][0]["delta"]["content"]                               
+                       
+                    history[-1] = gpt_replying_buffer
+                    chatbot[-1] = (history[-2], history[-1])
+                    yield from update_ui(chatbot=chatbot, history=history, msg=status_text) # 刷新界面
+
+                except Exception as e:
+                    traceback.print_exc()
+                    yield from update_ui(chatbot=chatbot, history=history, msg="Json解析不合常规") # 刷新界面
+                    chunk = get_full_error(chunk, stream_response)
+                    
+                    error_msg = chunk                    
+                    yield from update_ui(chatbot=chatbot, history=history, msg="Json异常" + error_msg) # 刷新界面
+                    return
+
+
+def predict_no_ui_long_connection(inputs, llm_kwargs, history=[], sys_prompt="", observe_window=None, console_slience=False):
+    """
+    发送至AZURE OPENAI API，等待回复，一次性完成，不显示中间过程。但内部用stream的方法避免中途网线被掐。
+    inputs：
+        是本次问询的输入
+    sys_prompt:
+        系统静默prompt
+    llm_kwargs：
+        chatGPT的内部调优参数
+    history：
+        是之前的对话列表
+    observe_window = None：
+        用于负责跨越线程传递已经输出的部分，大部分时候仅仅为了fancy的视觉效果，留空即可。observe_window[0]：观测窗。observe_window[1]：看门狗
+    """
+    watch_dog_patience = 5 # 看门狗的耐心, 设置5秒即可
+    payload = generate_azure_payload(inputs, llm_kwargs, history, system_prompt=sys_prompt, stream=True)
+    retry = 0
+    while True:
+
+        try:
+            openai.api_type = "azure"            
+            openai.api_version = AZURE_API_VERSION
+            openai.api_base = AZURE_ENDPOINT
+            openai.api_key = AZURE_API_KEY
+            response = openai.ChatCompletion.create(timeout=TIMEOUT_SECONDS, **payload);break
+        
+        except:  
+            retry += 1
+            traceback.print_exc()
+            if retry > MAX_RETRY: raise TimeoutError
+            if MAX_RETRY!=0: print(f'请求超时，正在重试 ({retry}/{MAX_RETRY}) ……')     
+        
+
+    stream_response =  response
+    result = ''
+    while True:
+        try: chunk = next(stream_response)
+        except StopIteration: 
+            break
+        except:
+            chunk = next(stream_response) # 失败了，重试一次？再失败就没办法了。
+
+        if len(chunk)==0: continue
+        if not chunk.startswith('data:'): 
+            error_msg = get_full_error(chunk, stream_response)
+            if "reduce the length" in error_msg:
+                raise ConnectionAbortedError("AZURE OPENAI API拒绝了请求:" + error_msg)
+            else:
+                raise RuntimeError("AZURE OPENAI API拒绝了请求：" + error_msg)
+        if ('data: [DONE]' in chunk): break 
+        
+        delta = chunk["delta"]
+        if len(delta) == 0: break
+        if "role" in delta: continue
+        if "content" in delta: 
+            result += delta["content"]
+            if not console_slience: print(delta["content"], end='')
+            if observe_window is not None: 
+                # 观测窗，把已经获取的数据显示出去
+                if len(observe_window) >= 1: observe_window[0] += delta["content"]
+                # 看门狗，如果超过期限没有喂狗，则终止
+                if len(observe_window) >= 2:  
+                    if (time.time()-observe_window[1]) > watch_dog_patience:
+                        raise RuntimeError("用户取消了程序。")
+        else: raise RuntimeError("意外Json结构："+delta)
+    if chunk['finish_reason'] == 'length':
+        raise ConnectionAbortedError("正常结束，但显示Token不足，导致输出不完整，请削减单次输入的文本量。")
+    return result
+
+
+def generate_azure_payload(inputs, llm_kwargs, history, system_prompt, stream):
+    """
+    整合所有信息，选择LLM模型，生成 azure openai api请求，为发送请求做准备
+    """    
+
+    conversation_cnt = len(history) // 2
+
+    messages = [{"role": "system", "content": system_prompt}]
+    if conversation_cnt:
+        for index in range(0, 2*conversation_cnt, 2):
+            what_i_have_asked = {}
+            what_i_have_asked["role"] = "user"
+            what_i_have_asked["content"] = history[index]
+            what_gpt_answer = {}
+            what_gpt_answer["role"] = "assistant"
+            what_gpt_answer["content"] = history[index+1]
+            if what_i_have_asked["content"] != "":
+                if what_gpt_answer["content"] == "": continue                
+                messages.append(what_i_have_asked)
+                messages.append(what_gpt_answer)
+            else:
+                messages[-1]['content'] = what_gpt_answer['content']
+
+    what_i_ask_now = {}
+    what_i_ask_now["role"] = "user"
+    what_i_ask_now["content"] = inputs
+    messages.append(what_i_ask_now)
+
+    payload = {
+        "model": llm_kwargs['llm_model'],
+        "messages": messages, 
+        "temperature": llm_kwargs['temperature'],  # 1.0,
+        "top_p": llm_kwargs['top_p'],  # 1.0,
+        "n": 1,
+        "stream": stream,
+        "presence_penalty": 0,
+        "frequency_penalty": 0,
+        "engine": AZURE_ENGINE
+    }
+    try:
+        print(f" {llm_kwargs['llm_model']} : {conversation_cnt} : {inputs[:100]} ..........")
+    except:
+        print('输入中可能存在乱码。')
+    return payload
+
+


### PR DESCRIPTION
在国内连openai的服务器总是有点麻烦，可以通过Microsoft Azure云服务中提供的 azure openai api 曲线救国。
这样不仅无需翻墙，账号注册也相对简单(注册用国内信用卡就行，有几率获得第一个月200美元的免费试用额度）
![image](https://github.com/binary-husky/gpt_academic/assets/85986768/cc48e238-d961-4ba4-980a-6b5107f6b594)



1. 在 `config.py` 中增加了关于AZURE的配置，包括`AZURE_ENDPOINT`（也叫base）, `AZURE_API_KEY`，`AZURE_API_VERSION`，`AZURE_ENGINE`。注册了azure账号，并申请了azure openai api后可以查看到
![image](https://github.com/binary-husky/gpt_academic/assets/85986768/770fabf6-c0dc-4ca6-8159-20cef0514fea)

2. 新增了`bridge_azure_test.py`，基本参考了原来的`bridge_chatgpt.py`中的代码。
3. 在 `bridge_all.py` 中增加了相关的 `model_info`


另外，`config.py` 文件中，需要在`AVAIL_LLM_MODELS`列表中，增加一个`"azure-gpt35"`模型名称
