### PR TITLE
🐛 匹配latex注释的正则表达式

### DIFF
--- a/crazy_functions/Latex全文润色.py
+++ b/crazy_functions/Latex全文润色.py
@@ -66,7 +66,7 @@ def 多文件润色(file_manifest, project_folder, llm_kwargs, plugin_kwargs, ch
         with open(fp, 'r', encoding='utf-8', errors='replace') as f:
             file_content = f.read()
             # 定义注释的正则表达式
-            comment_pattern = r'%.*'
+            comment_pattern = r'(?<!\\)%.*'
             # 使用正则表达式查找注释，并替换为空字符串
             clean_tex_content = re.sub(comment_pattern, '', file_content)
             # 记录删除注释后的文本
@@ -238,5 +238,3 @@ def Latex英文纠错(txt, llm_kwargs, plugin_kwargs, chatbot, history, system_p
         yield from update_ui(chatbot=chatbot, history=history) # 刷新界面
         return
     yield from 多文件润色(file_manifest, project_folder, llm_kwargs, plugin_kwargs, chatbot, history, system_prompt, language='en', mode='proofread')
-
-

--- a/crazy_functions/Latex全文翻译.py
+++ b/crazy_functions/Latex全文翻译.py
@@ -46,7 +46,7 @@ def 多文件翻译(file_manifest, project_folder, llm_kwargs, plugin_kwargs, ch
         with open(fp, 'r', encoding='utf-8', errors='replace') as f:
             file_content = f.read()
             # 定义注释的正则表达式
-            comment_pattern = r'%.*'
+            comment_pattern = r'(?<!\\)%.*'
             # 使用正则表达式查找注释，并替换为空字符串
             clean_tex_content = re.sub(comment_pattern, '', file_content)
             # 记录删除注释后的文本


### PR DESCRIPTION
以前的正则会把转义的百分号 `\%` 的 `%` 号也当注释，然后删掉。这里使用后视断言防止出现这种情况。