### PR TITLE
解决new bing 报错200 (fix new bing error code 200 )

### DIFF
--- a/request_llm/edge_gpt_free.py
+++ b/request_llm/edge_gpt_free.py
@@ -447,6 +447,15 @@ class _ChatHub:
         """
         Ask a question to the bot
         """
+        req_header = HEADERS
+        if self.cookies is not None:
+            ws_cookies = []
+            for cookie in self.cookies:
+                ws_cookies.append(f"{cookie['name']}={cookie['value']}")
+            req_header.update({
+                'Cookie': ';'.join(ws_cookies),
+            })
+            
         timeout = aiohttp.ClientTimeout(total=30)
         self.session = aiohttp.ClientSession(timeout=timeout)
 
@@ -455,7 +464,7 @@ class _ChatHub:
         # Check if websocket is closed
         self.wss = await self.session.ws_connect(
             wss_link,
-            headers=HEADERS,
+            headers=req_header,
             ssl=ssl_context,
             proxy=self.proxy,
             autoping=False,


### PR DESCRIPTION
modify from https://github.com/acheong08/EdgeGPT/pull/610/commits/16e00af9d55e1e32c4389512b02cac1c7eca4672

works for my issue:
```
Traceback (most recent call last):
  File "./request_llm/bridge_newbingfree.py", line 152, in run
    asyncio.run(self.async_run())
  File "/root/miniconda3/envs/py311/lib/python3.11/asyncio/runners.py", line 190, in run
    return runner.run(main)
           ^^^^^^^^^^^^^^^^
  File "/root/miniconda3/envs/py311/lib/python3.11/asyncio/runners.py", line 118, in run
    return self._loop.run_until_complete(task)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/miniconda3/envs/py311/lib/python3.11/asyncio/base_events.py", line 653, in run_until_complete
    return future.result()
           ^^^^^^^^^^^^^^^
  File "./request_llm/bridge_newbingfree.py", line 98, in async_run
    async for final, response in self.newbing_model.ask_stream(
  File "./request_llm/edge_gpt_free.py", line 676, in ask_stream
    async for response in self.chat_hub.ask_stream(
  File "./request_llm/edge_gpt_free.py", line 456, in ask_stream
    self.wss = await self.session.ws_connect(
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/miniconda3/envs/py311/lib/python3.11/site-packages/aiohttp/client.py", line 795, in _ws_connect
    raise WSServerHandshakeError(
aiohttp.client_exceptions.WSServerHandshakeError: 200, message='Invalid response status', url=URL('wss://sydney.bing.com/sydney/ChatHub')
``` 
![image](https://github.com/binary-husky/gpt_academic/assets/40739351/8356f5e4-8523-43cc-b194-a982df483a37)
