### PR TITLE
默认仅 clone 最新的代码，减小 git clone 的大小

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ python -m pip install -r request_llm/requirements_chatglm.txt
 
 # 【可选步骤II】支持复旦MOSS
 python -m pip install -r request_llm/requirements_moss.txt
-git clone https://github.com/OpenLMLab/MOSS.git request_llm/moss  # 注意执行此行代码时，必须处于项目根路径
+git clone --depth=1 https://github.com/OpenLMLab/MOSS.git request_llm/moss  # 注意执行此行代码时，必须处于项目根路径
 
 # 【可选步骤III】确保config.py配置文件的AVAIL_LLM_MODELS包含了期望的模型，目前支持的全部模型如下(jittorllms系列目前仅支持docker方案)：
 AVAIL_LLM_MODELS = ["gpt-3.5-turbo", "api2d-gpt-3.5-turbo", "gpt-4", "api2d-gpt-4", "chatglm", "newbing", "moss"] # + ["jittorllms_rwkv", "jittorllms_pangualpha", "jittorllms_llama"]
@@ -149,7 +149,7 @@ python main.py
 [![basiclatex](https://github.com/binary-husky/gpt_academic/actions/workflows/build-with-latex.yml/badge.svg?branch=master)](https://github.com/binary-husky/gpt_academic/actions/workflows/build-with-latex.yml)
 
 ``` sh
-git clone https://github.com/binary-husky/gpt_academic.git  # 下载项目
+git clone --depth=1 https://github.com/binary-husky/gpt_academic.git  # 下载项目
 cd gpt_academic                                 # 进入路径
 nano config.py                                      # 用任意文本编辑器编辑config.py, 配置 “Proxy”， “API_KEY” 以及 “WEB_PORT” (例如50923) 等
 docker build -t gpt-academic .                      # 安装

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Latex论文一键校对 | [函数插件] 仿Grammarly对Latex文章进行语法�
 
 1. 下载项目
 ```sh
-git clone https://github.com/binary-husky/gpt_academic.git
+git clone --depth=1 https://github.com/binary-husky/gpt_academic.git
 cd gpt_academic
 ```
 


### PR DESCRIPTION
tl; dr
- git clone 添加了 `--depth=1` 参数，加速 clone
- 开发者建议 clone 完整项目，便于查看历史提交

效果对比，9.56 MiB/59.28 MiB 大概只用 clone 1/6 大小.
随着项目的开发，项目历时约长，repo size 越大，效果越明显。
```
PS S:\academic> git clone --depth=1 https://github.com/binary-husky/gpt_academic.git
Cloning into 'gpt_academic'...
remote: Enumerating objects: 170, done.
remote: Counting objects: 100% (170/170), done.
remote: Compressing objects: 100% (154/154), done.
remote: Total 170 (delta 14), reused 118 (delta 11), pack-reused 0
Receiving objects: 100% (170/170), 9.56 MiB | 1.06 MiB/s, done.
Resolving deltas: 100% (14/14), done.

PS S:\academic> git clone https://github.com/binary-husky/gpt_academic.git gpt_academic_full
Cloning into 'gpt_academic_full'...
remote: Enumerating objects: 7500, done.
remote: Total 7500 (delta 0), reused 0 (delta 0), pack-reused 7500
Receiving objects: 100% (7500/7500), 59.28 MiB | 2.07 MiB/s, done.
Resolving deltas: 100% (4715/4715), done.
```

项目中其实已经在部分使用了 
https://github.com/binary-husky/gpt_academic/blob/a393edfaa4c0b774b5cb41c02f0b79d0a9b8b6d5/docs/Dockerfile%2BJittorLLM#L37


当然这样做就看不到历史提交记录了，因为仅拉去了最新的那个 commit。
如果想重新 fetch 所有记录，可以 `git pull --unshallow`
参考：[加速几十倍 git clone 速度的 --depth 1，它的后遗症怎么解决？ - 知乎](https://zhuanlan.zhihu.com/p/597688197)
