### PR TITLE
fix bug  #1167 学术小助手在proxies返回空时会首先尝试直接连接

### DIFF
--- a/crazy_functions/谷歌检索小助手.py
+++ b/crazy_functions/谷歌检索小助手.py
@@ -26,7 +26,13 @@ def get_meta_information(url, chatbot, history):
         'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7', 
         'Connection': 'keep-alive'
     }
-    session.proxies.update(proxies)
+    try:
+        session.proxies.update(proxies)
+    except:
+        report_execption(chatbot, history,
+                    a=f"获取代理失败 无代理状态下很可能无法访问OpenAI家族的模型及谷歌学术 建议：检查USE_PROXY选项是否修改。",
+                    b=f"尝试直接连接")
+        yield from update_ui(chatbot=chatbot, history=history)  # 刷新界面
     session.headers.update(headers)
 
     response = session.get(url)


### PR DESCRIPTION
添加了一个try语句,在proxies返回空时会首先尝试直接连接
之前:
![Screenshot_20231013_144424](https://user-images.githubusercontent.com/122662527/274817829-2733c412-c640-492b-bb68-ac7fbb20c145.png)
之后:
![Screenshot_20231013_153054](https://github.com/binary-husky/gpt_academic/assets/122662527/9eb01623-66e1-447d-8e22-92425307b0d3)
