### PR TITLE
修复了一个导致无法加载未量化的ChatGLM2 fine-tuning模型的问题

### DIFF
--- a/request_llm/bridge_chatglmft.py
+++ b/request_llm/bridge_chatglmft.py
@@ -87,7 +87,7 @@ class GetGLMFTHandle(Process):
                             new_prefix_state_dict[k[len("transformer.prefix_encoder."):]] = v
                     model.transformer.prefix_encoder.load_state_dict(new_prefix_state_dict)
 
-                    if model_args['quantization_bit'] is not None:
+                    if model_args['quantization_bit'] is not None and model_args['quantization_bit'] != 0:
                         print(f"Quantized to {model_args['quantization_bit']} bit")
                         model = model.quantize(model_args['quantization_bit'])
                     model = model.cuda()


### PR DESCRIPTION
修复了一个导致无法加载未量化的ChatGLM2 fine-tuning模型的问题：当模型的quantization_bit参数为0时，错误地尝试进行quantize会导致模型加载失败