### PR TITLE
dall-e作图模型调用错误的相关修正 && dall-e做图质量功能添加

### DIFF
--- a/crazy_functional.py
+++ b/crazy_functional.py
@@ -354,7 +354,7 @@ def get_crazy_functions():
         print('Load function plugin failed')
 
     try:
-        from crazy_functions.图片生成 import 图片生成_DALLE2, 图片生成_DALLE3_Standard, 图片生成_DALLE3_HD
+        from crazy_functions.图片生成 import 图片生成_DALLE2, 图片生成_DALLE3
         function_plugins.update({
             "图片生成_DALLE2 （先切换模型到openai或api2d）": {
                 "Group": "对话",
@@ -367,25 +367,14 @@ def get_crazy_functions():
             },
         })
         function_plugins.update({
-            "图片生成_DALLE3_Standard （先切换模型到openai或api2d）": {
+            "图片生成_DALLE3 （先切换模型到openai或api2d）": {
                 "Group": "对话",
                 "Color": "stop",
                 "AsButton": False,
                 "AdvancedArgs": True,  # 调用时，唤起高级参数输入区（默认False）
-                "ArgsReminder": "在这里输入分辨率, 如1024x1024（默认），支持 1024x1024, 1792x1024, 1024x1792",  # 高级参数输入区的显示提示
-                "Info": "使用DALLE3 standard质量生成图片 | 输入参数字符串，提供图像的内容",
-                "Function": HotReload(图片生成_DALLE3_Standard)
-            },
-        })
-        function_plugins.update({
-            "图片生成_DALLE3_HD （先切换模型到openai或api2d）": {
-                "Group": "对话",
-                "Color": "stop",
-                "AsButton": False,
-                "AdvancedArgs": True,  # 调用时，唤起高级参数输入区（默认False）
-                "ArgsReminder": "在这里输入分辨率, 如1024x1024（默认），支持 1024x1024, 1792x1024, 1024x1792",  # 高级参数输入区的显示提示
-                "Info": "使用DALLE3 HD质量生成图片 | 输入参数字符串，提供图像的内容",
-                "Function": HotReload(图片生成_DALLE3_HD)
+                "ArgsReminder": "在这里输入分辨率, 如1024x1024（默认），支持 1024x1024, 1792x1024, 1024x1792。如需生成高清图像，请输入 1024x1024-HD, 1792x1024-HD, 1024x1792-HD。",  # 高级参数输入区的显示提示
+                "Info": "使用DALLE3生成图片 | 输入参数字符串，提供图像的内容",
+                "Function": HotReload(图片生成_DALLE3)
             },
         })
     except:

--- a/crazy_functional.py
+++ b/crazy_functional.py
@@ -354,7 +354,7 @@ def get_crazy_functions():
         print('Load function plugin failed')
 
     try:
-        from crazy_functions.图片生成 import 图片生成_DALLE2, 图片生成_DALLE3_Standard， 图片生成_DALLE3_HD
+        from crazy_functions.图片生成 import 图片生成_DALLE2, 图片生成_DALLE3_Standard, 图片生成_DALLE3_HD
         function_plugins.update({
             "图片生成_DALLE2 （先切换模型到openai或api2d）": {
                 "Group": "对话",

--- a/crazy_functional.py
+++ b/crazy_functional.py
@@ -374,7 +374,7 @@ def get_crazy_functions():
                 "AdvancedArgs": True,  # 调用时，唤起高级参数输入区（默认False）
                 "ArgsReminder": "在这里输入分辨率, 如1024x1024（默认），支持 1024x1024, 1792x1024, 1024x1792",  # 高级参数输入区的显示提示
                 "Info": "使用DALLE3 standard质量生成图片 | 输入参数字符串，提供图像的内容",
-                "Function": HotReload(图片生成_DALLE3)
+                "Function": HotReload(图片生成_DALLE3_Standard)
             },
         })
         function_plugins.update({
@@ -385,7 +385,7 @@ def get_crazy_functions():
                 "AdvancedArgs": True,  # 调用时，唤起高级参数输入区（默认False）
                 "ArgsReminder": "在这里输入分辨率, 如1024x1024（默认），支持 1024x1024, 1792x1024, 1024x1792",  # 高级参数输入区的显示提示
                 "Info": "使用DALLE3 HD质量生成图片 | 输入参数字符串，提供图像的内容",
-                "Function": HotReload(图片生成_DALLE3)
+                "Function": HotReload(图片生成_DALLE3_HD)
             },
         })
     except:

--- a/crazy_functional.py
+++ b/crazy_functional.py
@@ -354,7 +354,7 @@ def get_crazy_functions():
         print('Load function plugin failed')
 
     try:
-        from crazy_functions.图片生成 import 图片生成_DALLE2, 图片生成_DALLE3
+        from crazy_functions.图片生成 import 图片生成_DALLE2, 图片生成_DALLE3_Standard， 图片生成_DALLE3_HD
         function_plugins.update({
             "图片生成_DALLE2 （先切换模型到openai或api2d）": {
                 "Group": "对话",
@@ -367,13 +367,24 @@ def get_crazy_functions():
             },
         })
         function_plugins.update({
-            "图片生成_DALLE3 （先切换模型到openai或api2d）": {
+            "图片生成_DALLE3_Standard （先切换模型到openai或api2d）": {
                 "Group": "对话",
                 "Color": "stop",
                 "AsButton": False,
                 "AdvancedArgs": True,  # 调用时，唤起高级参数输入区（默认False）
                 "ArgsReminder": "在这里输入分辨率, 如1024x1024（默认），支持 1024x1024, 1792x1024, 1024x1792",  # 高级参数输入区的显示提示
-                "Info": "使用DALLE3生成图片 | 输入参数字符串，提供图像的内容",
+                "Info": "使用DALLE3 standard质量生成图片 | 输入参数字符串，提供图像的内容",
+                "Function": HotReload(图片生成_DALLE3)
+            },
+        })
+        function_plugins.update({
+            "图片生成_DALLE3_HD （先切换模型到openai或api2d）": {
+                "Group": "对话",
+                "Color": "stop",
+                "AsButton": False,
+                "AdvancedArgs": True,  # 调用时，唤起高级参数输入区（默认False）
+                "ArgsReminder": "在这里输入分辨率, 如1024x1024（默认），支持 1024x1024, 1792x1024, 1024x1792",  # 高级参数输入区的显示提示
+                "Info": "使用DALLE3 HD质量生成图片 | 输入参数字符串，提供图像的内容",
                 "Function": HotReload(图片生成_DALLE3)
             },
         })

--- a/crazy_functions/图片生成.py
+++ b/crazy_functions/图片生成.py
@@ -2,7 +2,7 @@ from toolbox import CatchException, update_ui, get_conf, select_api_key, get_log
 from crazy_functions.multi_stage.multi_stage_utils import GptAcademicState
 
 
-def gen_image(llm_kwargs, prompt, resolution="1024x1024", model="dall-e-2"):
+def gen_image(llm_kwargs, prompt, resolution="1024x1024", model="dall-e-2", quality=None):
     import requests, json, time, os
     from request_llms.bridge_all import model_info
 
@@ -25,47 +25,7 @@ def gen_image(llm_kwargs, prompt, resolution="1024x1024", model="dall-e-2"):
         'model': model,
         'response_format': 'url'
     }
-    response = requests.post(url, headers=headers, json=data, proxies=proxies)
-    print(response.content)
-    try:
-        image_url = json.loads(response.content.decode('utf8'))['data'][0]['url']
-    except:
-        raise RuntimeError(response.content.decode())
-    # 文件保存到本地
-    r = requests.get(image_url, proxies=proxies)
-    file_path = f'{get_log_folder()}/image_gen/'
-    os.makedirs(file_path, exist_ok=True)
-    file_name = 'Image' + time.strftime("%Y-%m-%d-%H-%M-%S", time.localtime()) + '.png'
-    with open(file_path+file_name, 'wb+') as f: f.write(r.content)
-
-
-    return image_url, file_path+file_name
-
-
-def gen_image_dalle3(quality, llm_kwargs, prompt, resolution="1024x1024", model="dall-e-3"):
-    import requests, json, time, os
-    from request_llms.bridge_all import model_info
-
-    proxies = get_conf('proxies')
-    # Set up OpenAI API key and model 
-    api_key = select_api_key(llm_kwargs['api_key'], llm_kwargs['llm_model'])
-    chat_endpoint = model_info[llm_kwargs['llm_model']]['endpoint']
-    # 'https://api.openai.com/v1/chat/completions'
-    img_endpoint = chat_endpoint.replace('chat/completions','images/generations')
-    # # Generate the image
-    url = img_endpoint
-    headers = {
-        'Authorization': f"Bearer {api_key}",
-        'Content-Type': 'application/json'
-    }
-    data = {
-        'prompt': prompt,
-        'n': 1,
-        'size': resolution,
-        'quality': quality,
-        'model': model,
-        'response_format': 'url'
-    }
+    if quality is not None: data.update({'quality': quality})
     response = requests.post(url, headers=headers, json=data, proxies=proxies)
     print(response.content)
     try:
@@ -126,17 +86,17 @@ def edit_image(llm_kwargs, prompt, image_path, resolution="1024x1024", model="da
 @CatchException
 def 图片生成_DALLE2(prompt, llm_kwargs, plugin_kwargs, chatbot, history, system_prompt, web_port):
     """
-    txt             输入栏用户输入的文本，例如需要翻译的一段话，再例如一个包含了待处理文件的路径
-    llm_kwargs      gpt模型参数，如温度和top_p等，一般原样传递下去就行
-    plugin_kwargs   插件模型的参数，暂时没有用武之地
-    chatbot         聊天显示框的句柄，用于显示给用户
-    history         聊天历史，前情提要
+    txt             输入栏用户输入的文本,例如需要翻译的一段话,再例如一个包含了待处理文件的路径
+    llm_kwargs      gpt模型参数,如温度和top_p等,一般原样传递下去就行
+    plugin_kwargs   插件模型的参数,暂时没有用武之地
+    chatbot         聊天显示框的句柄,用于显示给用户
+    history         聊天历史,前情提要
     system_prompt   给gpt的静默提醒
     web_port        当前软件运行的端口号
     """
-    history = []    # 清空历史，以免输入溢出
-    chatbot.append(("这是什么功能？", "[Local Message] 生成图像, 请先把模型切换至gpt-*或者api2d-*。如果中文效果不理想, 请尝试英文Prompt。正在处理中 ....."))
-    yield from update_ui(chatbot=chatbot, history=history) # 刷新界面 # 由于请求gpt需要一段时间，我们先及时地做一次界面更新
+    history = []    # 清空历史,以免输入溢出
+    chatbot.append(("您正在调用“图像生成”插件。", "[Local Message] 生成图像, 请先把模型切换至gpt-*或者api2d-*。如果中文Prompt效果不理想, 请尝试英文Prompt。正在处理中 ....."))
+    yield from update_ui(chatbot=chatbot, history=history) # 刷新界面 由于请求gpt需要一段时间,我们先及时地做一次界面更新
     if ("advanced_arg" in plugin_kwargs) and (plugin_kwargs["advanced_arg"] == ""): plugin_kwargs.pop("advanced_arg")
     resolution = plugin_kwargs.get("advanced_arg", '1024x1024')
     image_url, image_path = gen_image(llm_kwargs, prompt, resolution)
@@ -146,44 +106,32 @@ def 图片生成_DALLE2(prompt, llm_kwargs, plugin_kwargs, chatbot, history, sys
         f'本地文件地址: <br/>`{image_path}`<br/>'+
         f'本地文件预览: <br/><div align="center"><img src="file={image_path}"></div>'
     ])
-    yield from update_ui(chatbot=chatbot, history=history) # 刷新界面 # 界面更新
+    yield from update_ui(chatbot=chatbot, history=history) # 刷新界面 界面更新
 
 
 @CatchException
-def 图片生成_DALLE3_Standard(prompt, llm_kwargs, plugin_kwargs, chatbot, history, system_prompt, web_port):
-    history = []    # 清空历史，以免输入溢出
-    chatbot.append(("这是什么功能？", "[Local Message] 生成图像, 请先把模型切换至gpt-*或者api2d-*。如果中文效果不理想, 请尝试英文Prompt。正在处理中 ....."))
-    yield from update_ui(chatbot=chatbot, history=history) # 刷新界面 # 由于请求gpt需要一段时间，我们先及时地做一次界面更新
+def 图片生成_DALLE3(prompt, llm_kwargs, plugin_kwargs, chatbot, history, system_prompt, web_port):
+    history = []    # 清空历史,以免输入溢出
+    chatbot.append(("您正在调用“图像生成”插件。", "[Local Message] 生成图像, 请先把模型切换至gpt-*或者api2d-*。如果中文Prompt效果不理想, 请尝试英文Prompt。正在处理中 ....."))
+    yield from update_ui(chatbot=chatbot, history=history) # 刷新界面 由于请求gpt需要一段时间,我们先及时地做一次界面更新
     if ("advanced_arg" in plugin_kwargs) and (plugin_kwargs["advanced_arg"] == ""): plugin_kwargs.pop("advanced_arg")
-    resolution = plugin_kwargs.get("advanced_arg", '1024x1024')
-    image_url, image_path = gen_image_dalle3("standard", llm_kwargs, prompt, resolution)
+    resolution = plugin_kwargs.get("advanced_arg", '1024x1024').lower()
+    if resolution.endswith('-hd'):
+        resolution = resolution.replace('-hd', '')
+        quality = 'hd'
+    else:
+        quality = 'standard'
+    image_url, image_path = gen_image(llm_kwargs, prompt, resolution, model="dall-e-3", quality=quality)
     chatbot.append([prompt,  
         f'图像中转网址: <br/>`{image_url}`<br/>'+
         f'中转网址预览: <br/><div align="center"><img src="{image_url}"></div>'
         f'本地文件地址: <br/>`{image_path}`<br/>'+
         f'本地文件预览: <br/><div align="center"><img src="file={image_path}"></div>'
     ])
-    yield from update_ui(chatbot=chatbot, history=history) # 刷新界面 # 界面更新
-
-
-@CatchException
-def 图片生成_DALLE3_HD(prompt, llm_kwargs, plugin_kwargs, chatbot, history, system_prompt, web_port):
-    history = []    # 清空历史，以免输入溢出
-    chatbot.append(("这是什么功能？", "[Local Message] 生成图像, 请先把模型切换至gpt-*或者api2d-*。如果中文效果不理想, 请尝试英文Prompt。正在处理中 ....."))
-    yield from update_ui(chatbot=chatbot, history=history) # 刷新界面 # 由于请求gpt需要一段时间，我们先及时地做一次界面更新
-    if ("advanced_arg" in plugin_kwargs) and (plugin_kwargs["advanced_arg"] == ""): plugin_kwargs.pop("advanced_arg")
-    resolution = plugin_kwargs.get("advanced_arg", '1024x1024')
-    image_url, image_path = gen_image_dalle3("hd", llm_kwargs, prompt, resolution)
-    chatbot.append([prompt,  
-        f'图像中转网址: <br/>`{image_url}`<br/>'+
-        f'中转网址预览: <br/><div align="center"><img src="{image_url}"></div>'
-        f'本地文件地址: <br/>`{image_path}`<br/>'+
-        f'本地文件预览: <br/><div align="center"><img src="file={image_path}"></div>'
-    ])
-    yield from update_ui(chatbot=chatbot, history=history) # 刷新界面 # 界面更新
-
+    yield from update_ui(chatbot=chatbot, history=history) # 刷新界面 界面更新
 
 class ImageEditState(GptAcademicState):
+    # 尚未完成
     def get_image_file(self, x):
         import os, glob
         if len(x) == 0:             return False, None
@@ -204,8 +152,8 @@ class ImageEditState(GptAcademicState):
     def reset(self):
         self.req = [
             {'value':None, 'description': '请先上传图像（必须是.png格式）, 然后再次点击本插件',    'verify_fn': self.get_image_file},
-            {'value':None, 'description': '请输入分辨率，可选：256x256, 512x512 或 1024x1024',   'verify_fn': self.get_resolution},
-            {'value':None, 'description': '请输入修改需求，建议您使用英文提示词',                 'verify_fn': self.get_prompt},
+            {'value':None, 'description': '请输入分辨率,可选：256x256, 512x512 或 1024x1024',   'verify_fn': self.get_resolution},
+            {'value':None, 'description': '请输入修改需求,建议您使用英文提示词',                 'verify_fn': self.get_prompt},
         ]
         self.info = ""
 
@@ -230,11 +178,12 @@ class ImageEditState(GptAcademicState):
 
 @CatchException
 def 图片修改_DALLE2(prompt, llm_kwargs, plugin_kwargs, chatbot, history, system_prompt, web_port):
+    # 尚未完成
     history = []    # 清空历史
     state = ImageEditState.get_state(chatbot, ImageEditState)
     state = state.feed(prompt, chatbot)
     if not state.already_obtained_all_materials():
-        chatbot.append(["图片修改（先上传图片，再输入修改需求，最后输入分辨率）", state.next_req()])
+        chatbot.append(["图片修改（先上传图片,再输入修改需求,最后输入分辨率）", state.next_req()])
         yield from update_ui(chatbot=chatbot, history=history)
         return
 
@@ -251,5 +200,5 @@ def 图片修改_DALLE2(prompt, llm_kwargs, plugin_kwargs, chatbot, history, sys
         f'本地文件地址: <br/>`{image_path}`<br/>'+
         f'本地文件预览: <br/><div align="center"><img src="file={image_path}"></div>'
     ])
-    yield from update_ui(chatbot=chatbot, history=history) # 刷新界面 # 界面更新
+    yield from update_ui(chatbot=chatbot, history=history) # 刷新界面 界面更新
 

--- a/crazy_functions/图片生成.py
+++ b/crazy_functions/图片生成.py
@@ -156,7 +156,7 @@ def 图片生成_DALLE3_Standard(prompt, llm_kwargs, plugin_kwargs, chatbot, his
     yield from update_ui(chatbot=chatbot, history=history) # 刷新界面 # 由于请求gpt需要一段时间，我们先及时地做一次界面更新
     if ("advanced_arg" in plugin_kwargs) and (plugin_kwargs["advanced_arg"] == ""): plugin_kwargs.pop("advanced_arg")
     resolution = plugin_kwargs.get("advanced_arg", '1024x1024')
-    image_url, image_path = gen_image_dalle3(standard, llm_kwargs, prompt, resolution)
+    image_url, image_path = gen_image_dalle3("standard", llm_kwargs, prompt, resolution)
     chatbot.append([prompt,  
         f'图像中转网址: <br/>`{image_url}`<br/>'+
         f'中转网址预览: <br/><div align="center"><img src="{image_url}"></div>'
@@ -173,7 +173,7 @@ def 图片生成_DALLE3_HD(prompt, llm_kwargs, plugin_kwargs, chatbot, history, 
     yield from update_ui(chatbot=chatbot, history=history) # 刷新界面 # 由于请求gpt需要一段时间，我们先及时地做一次界面更新
     if ("advanced_arg" in plugin_kwargs) and (plugin_kwargs["advanced_arg"] == ""): plugin_kwargs.pop("advanced_arg")
     resolution = plugin_kwargs.get("advanced_arg", '1024x1024')
-    image_url, image_path = gen_image_dalle3(HD, llm_kwargs, prompt, resolution)
+    image_url, image_path = gen_image_dalle3("HD", llm_kwargs, prompt, resolution)
     chatbot.append([prompt,  
         f'图像中转网址: <br/>`{image_url}`<br/>'+
         f'中转网址预览: <br/><div align="center"><img src="{image_url}"></div>'

--- a/crazy_functions/图片生成.py
+++ b/crazy_functions/图片生成.py
@@ -173,7 +173,7 @@ def 图片生成_DALLE3_HD(prompt, llm_kwargs, plugin_kwargs, chatbot, history, 
     yield from update_ui(chatbot=chatbot, history=history) # 刷新界面 # 由于请求gpt需要一段时间，我们先及时地做一次界面更新
     if ("advanced_arg" in plugin_kwargs) and (plugin_kwargs["advanced_arg"] == ""): plugin_kwargs.pop("advanced_arg")
     resolution = plugin_kwargs.get("advanced_arg", '1024x1024')
-    image_url, image_path = gen_image_dalle3("HD", llm_kwargs, prompt, resolution)
+    image_url, image_path = gen_image_dalle3("hd", llm_kwargs, prompt, resolution)
     chatbot.append([prompt,  
         f'图像中转网址: <br/>`{image_url}`<br/>'+
         f'中转网址预览: <br/><div align="center"><img src="{image_url}"></div>'


### PR DESCRIPTION
 - 修改原dall-e-3作图时仍调用dall-e-2模型的错误
 - 考虑到在「高级参数输入区」中输入图片相关参数可能难以规范用户输入格式，将原　“图片生成_DALLE3”　拆分为　“图片生成_DALLE3_Standard”　与　“图片生成_DALLE3_HD”　，可以以不同质量生成图片