### PR TITLE
dall-e-3添加风格参数选择 && 优化插件分类

### DIFF
--- a/config.py
+++ b/config.py
@@ -82,7 +82,7 @@ MAX_RETRY = 2
 
 
 # 插件分类默认选项
-DEFAULT_FN_GROUPS = ['对话', '编程', '学术', '智能体']
+DEFAULT_FN_GROUPS = ['对话&作图', '编程', '学术', '智能体']
 
 
 # 模型选择是 (注意: LLM_MODEL是默认选中的模型, 它*必须*被包含在AVAIL_LLM_MODELS列表中 )

--- a/crazy_functional.py
+++ b/crazy_functional.py
@@ -372,7 +372,7 @@ def get_crazy_functions():
                 "Color": "stop",
                 "AsButton": False,
                 "AdvancedArgs": True,  # 调用时，唤起高级参数输入区（默认False）
-                "ArgsReminder": "在这里输入自定义参数“分辨率-质量(可选)-风格(可选)”, 参数示例“1024x1024-hd-vivid”, 分辨率默认1024x1024, 支持 1024x1024//1792x1024//1024x1792; 质量默认-standard, 可选-standard//-hd; 风格默认-vivid, 可选-vivid//-natural",  # 高级参数输入区的显示提示
+                "ArgsReminder": "在这里输入自定义参数“分辨率-质量(可选)-风格(可选)”, 参数示例“1024x1024-hd-vivid” | 分辨率支持 1024x1024(默认)//1792x1024//1024x1792 | 质量支持 -standard(默认)//-hd | 风格支持 -vivid(默认)//-natural",  # 高级参数输入区的显示提示
                 "Info": "使用DALLE3生成图片 | 输入参数字符串，提供图像的内容",
                 "Function": HotReload(图片生成_DALLE3)
             },

--- a/crazy_functional.py
+++ b/crazy_functional.py
@@ -40,7 +40,7 @@ def get_crazy_functions():
 
     function_plugins = {
         "虚空终端": {
-            "Group": "对话|编程|学术|智能体",
+            "Group": "对话&作图|编程|学术|智能体",
             "Color": "stop",
             "AsButton": True,
             "Function": HotReload(虚空终端)
@@ -53,20 +53,20 @@ def get_crazy_functions():
             "Function": HotReload(解析一个Python项目)
         },
         "载入对话历史存档（先上传存档或输入路径）": {
-            "Group": "对话",
+            "Group": "对话&作图",
             "Color": "stop",
             "AsButton": False,
             "Info": "载入对话历史存档 | 输入参数为路径",
             "Function": HotReload(载入对话历史存档)
         },
         "删除所有本地对话历史记录（谨慎操作）": {
-            "Group": "对话",
+            "Group": "对话&作图",
             "AsButton": False,
             "Info": "删除所有本地对话历史记录，谨慎操作 | 不需要输入参数",
             "Function": HotReload(删除所有本地对话历史记录)
         },
         "清除所有缓存文件（谨慎操作）": {
-            "Group": "对话",
+            "Group": "对话&作图",
             "Color": "stop",
             "AsButton": False,  # 加入下拉菜单中
             "Info": "清除所有缓存文件，谨慎操作 | 不需要输入参数",
@@ -180,19 +180,19 @@ def get_crazy_functions():
             "Function": HotReload(批量生成函数注释)
         },
         "保存当前的对话": {
-            "Group": "对话",
+            "Group": "对话&作图",
             "AsButton": True,
             "Info": "保存当前的对话 | 不需要输入参数",
             "Function": HotReload(对话历史存档)
         },
         "[多线程Demo]解析此项目本身（源码自译解）": {
-            "Group": "对话|编程",
+            "Group": "对话&作图|编程",
             "AsButton": False,  # 加入下拉菜单中
             "Info": "多线程解析并翻译此项目的源码 | 不需要输入参数",
             "Function": HotReload(解析项目本身)
         },
         "历史上的今天": {
-            "Group": "对话",
+            "Group": "对话&作图",
             "AsButton": True,
             "Info": "查看历史上的今天事件 (这是一个面向开发者的插件Demo) | 不需要输入参数",
             "Function": HotReload(高阶功能模板函数)
@@ -205,7 +205,7 @@ def get_crazy_functions():
             "Function": HotReload(批量翻译PDF文档)
         },
         "询问多个GPT模型": {
-            "Group": "对话",
+            "Group": "对话&作图",
             "Color": "stop",
             "AsButton": True,
             "Function": HotReload(同时问询)
@@ -300,7 +300,7 @@ def get_crazy_functions():
         from crazy_functions.联网的ChatGPT import 连接网络回答问题
         function_plugins.update({
             "连接网络回答问题（输入问题后点击该插件，需要访问谷歌）": {
-                "Group": "对话",
+                "Group": "对话&作图",
                 "Color": "stop",
                 "AsButton": False,  # 加入下拉菜单中
                 # "Info": "连接网络回答问题（需要访问谷歌）| 输入参数是一个问题",
@@ -310,7 +310,7 @@ def get_crazy_functions():
         from crazy_functions.联网的ChatGPT_bing版 import 连接bing搜索回答问题
         function_plugins.update({
             "连接网络回答问题（中文Bing版，输入问题后点击该插件）": {
-                "Group": "对话",
+                "Group": "对话&作图",
                 "Color": "stop",
                 "AsButton": False,  # 加入下拉菜单中
                 "Info": "连接网络回答问题（需要访问中文Bing）| 输入参数是一个问题",
@@ -341,7 +341,7 @@ def get_crazy_functions():
         from crazy_functions.询问多个大语言模型 import 同时问询_指定模型
         function_plugins.update({
             "询问多个GPT模型（手动指定询问哪些模型）": {
-                "Group": "对话",
+                "Group": "对话&作图",
                 "Color": "stop",
                 "AsButton": False,
                 "AdvancedArgs": True,  # 调用时，唤起高级参数输入区（默认False）
@@ -357,7 +357,7 @@ def get_crazy_functions():
         from crazy_functions.图片生成 import 图片生成_DALLE2, 图片生成_DALLE3
         function_plugins.update({
             "图片生成_DALLE2 （先切换模型到openai或api2d）": {
-                "Group": "对话",
+                "Group": "对话&作图",
                 "Color": "stop",
                 "AsButton": False,
                 "AdvancedArgs": True,  # 调用时，唤起高级参数输入区（默认False）
@@ -368,7 +368,7 @@ def get_crazy_functions():
         })
         function_plugins.update({
             "图片生成_DALLE3 （先切换模型到openai或api2d）": {
-                "Group": "对话",
+                "Group": "对话&作图",
                 "Color": "stop",
                 "AsButton": False,
                 "AdvancedArgs": True,  # 调用时，唤起高级参数输入区（默认False）
@@ -385,7 +385,7 @@ def get_crazy_functions():
         from crazy_functions.总结音视频 import 总结音视频
         function_plugins.update({
             "批量总结音视频（输入路径或上传压缩包）": {
-                "Group": "对话",
+                "Group": "对话&作图",
                 "Color": "stop",
                 "AsButton": False,
                 "AdvancedArgs": True,
@@ -402,7 +402,7 @@ def get_crazy_functions():
         from crazy_functions.数学动画生成manim import 动画生成
         function_plugins.update({
             "数学动画生成（Manim）": {
-                "Group": "对话",
+                "Group": "对话&作图",
                 "Color": "stop",
                 "AsButton": False,
                 "Info": "按照自然语言描述生成一个动画 | 输入参数是一段话",
@@ -433,7 +433,7 @@ def get_crazy_functions():
         from crazy_functions.Langchain知识库 import 知识库问答
         function_plugins.update({
             "构建知识库（先上传文件素材,再运行此插件）": {
-                "Group": "对话",
+                "Group": "对话&作图",
                 "Color": "stop",
                 "AsButton": False,
                 "AdvancedArgs": True,
@@ -449,7 +449,7 @@ def get_crazy_functions():
         from crazy_functions.Langchain知识库 import 读取知识库作答
         function_plugins.update({
             "知识库问答（构建知识库后,再运行此插件）": {
-                "Group": "对话",
+                "Group": "对话&作图",
                 "Color": "stop",
                 "AsButton": False,
                 "AdvancedArgs": True,
@@ -465,7 +465,7 @@ def get_crazy_functions():
         from crazy_functions.交互功能函数模板 import 交互功能模板函数
         function_plugins.update({
             "交互功能模板Demo函数（查找wallhaven.cc的壁纸）": {
-                "Group": "对话",
+                "Group": "对话&作图",
                 "Color": "stop",
                 "AsButton": False,
                 "Function": HotReload(交互功能模板函数)
@@ -527,7 +527,7 @@ def get_crazy_functions():
             from crazy_functions.语音助手 import 语音助手
             function_plugins.update({
                 "实时语音对话": {
-                    "Group": "对话",
+                    "Group": "对话&作图",
                     "Color": "stop",
                     "AsButton": True,
                     "Info": "这是一个时刻聆听着的语音对话助手 | 没有输入参数",

--- a/crazy_functional.py
+++ b/crazy_functional.py
@@ -372,7 +372,7 @@ def get_crazy_functions():
                 "Color": "stop",
                 "AsButton": False,
                 "AdvancedArgs": True,  # 调用时，唤起高级参数输入区（默认False）
-                "ArgsReminder": "在这里输入自定义参数“分辨率-质量(可选)-风格(可选)”, 参数示例“1024x1024-hd-vivid” | 分辨率支持 1024x1024(默认)//1792x1024//1024x1792 | 质量支持 -standard(默认)//-hd | 风格支持 -vivid(默认)//-natural",  # 高级参数输入区的显示提示
+                "ArgsReminder": "在这里输入自定义参数“分辨率-质量(可选)-风格(可选)”, 参数示例“1024x1024-hd-vivid” || 分辨率支持 1024x1024(默认)//1792x1024//1024x1792 || 质量支持 -standard(默认)//-hd || 风格支持 -vivid(默认)//-natural",  # 高级参数输入区的显示提示
                 "Info": "使用DALLE3生成图片 | 输入参数字符串，提供图像的内容",
                 "Function": HotReload(图片生成_DALLE3)
             },

--- a/crazy_functional.py
+++ b/crazy_functional.py
@@ -372,7 +372,7 @@ def get_crazy_functions():
                 "Color": "stop",
                 "AsButton": False,
                 "AdvancedArgs": True,  # 调用时，唤起高级参数输入区（默认False）
-                "ArgsReminder": "在这里输入分辨率, 如1024x1024（默认），支持 1024x1024, 1792x1024, 1024x1792。如需生成高清图像，请输入 1024x1024-HD, 1792x1024-HD, 1024x1792-HD。",  # 高级参数输入区的显示提示
+                "ArgsReminder": "在这里输入自定义参数“分辨率-质量(可选)-风格(可选)”, 参数示例“1024x1024-hd-vivid”, 分辨率默认1024x1024, 支持 1024x1024//1792x1024//1024x1792; 质量默认-standard, 可选-standard//-hd; 风格默认-vivid, 可选-vivid//-natural",  # 高级参数输入区的显示提示
                 "Info": "使用DALLE3生成图片 | 输入参数字符串，提供图像的内容",
                 "Function": HotReload(图片生成_DALLE3)
             },

--- a/crazy_functions/图片生成.py
+++ b/crazy_functions/图片生成.py
@@ -2,7 +2,7 @@ from toolbox import CatchException, update_ui, get_conf, select_api_key, get_log
 from crazy_functions.multi_stage.multi_stage_utils import GptAcademicState
 
 
-def gen_image(llm_kwargs, prompt, resolution="1024x1024", model="dall-e-2", quality=None):
+def gen_image(llm_kwargs, prompt, resolution="1024x1024", model="dall-e-2", quality=None, style=None):
     import requests, json, time, os
     from request_llms.bridge_all import model_info
 
@@ -25,7 +25,10 @@ def gen_image(llm_kwargs, prompt, resolution="1024x1024", model="dall-e-2", qual
         'model': model,
         'response_format': 'url'
     }
-    if quality is not None: data.update({'quality': quality})
+    if quality is not None:
+        data['quality'] = quality
+    if style is not None:
+        data['style'] = style
     response = requests.post(url, headers=headers, json=data, proxies=proxies)
     print(response.content)
     try:
@@ -115,13 +118,18 @@ def 图片生成_DALLE3(prompt, llm_kwargs, plugin_kwargs, chatbot, history, sys
     chatbot.append(("您正在调用“图像生成”插件。", "[Local Message] 生成图像, 请先把模型切换至gpt-*或者api2d-*。如果中文Prompt效果不理想, 请尝试英文Prompt。正在处理中 ....."))
     yield from update_ui(chatbot=chatbot, history=history) # 刷新界面 由于请求gpt需要一段时间,我们先及时地做一次界面更新
     if ("advanced_arg" in plugin_kwargs) and (plugin_kwargs["advanced_arg"] == ""): plugin_kwargs.pop("advanced_arg")
-    resolution = plugin_kwargs.get("advanced_arg", '1024x1024').lower()
-    if resolution.endswith('-hd'):
-        resolution = resolution.replace('-hd', '')
-        quality = 'hd'
-    else:
-        quality = 'standard'
-    image_url, image_path = gen_image(llm_kwargs, prompt, resolution, model="dall-e-3", quality=quality)
+    resolution_arg = plugin_kwargs.get("advanced_arg", '1024x1024-standard-vivid').lower()
+    parts = resolution_arg.split('-')
+    resolution = parts[0] # 解析分辨率
+    quality = 'standard' # 质量与风格默认值
+    style = 'vivid'
+    # 遍历检查是否有额外参数
+    for part in parts[1:]:
+        if part in ['hd', 'standard']:
+            quality = part
+        elif part in ['vivid', 'natural']:
+            style = part
+    image_url, image_path = gen_image(llm_kwargs, prompt, resolution, model="dall-e-3", quality=quality, style=style)
     chatbot.append([prompt,  
         f'图像中转网址: <br/>`{image_url}`<br/>'+
         f'中转网址预览: <br/><div align="center"><img src="{image_url}"></div>'


### PR DESCRIPTION
 - dall-e-3添加 'style' 风格参数（参考 [platform.openai.com/doc/api-reference](https://platform.openai.com/docs/api-reference/images)），优化了dall-e-3作图时的参数判断逻辑（也有可能是负优化x，仅供参考） 
 BTW, 「openai参数对大小写敏感」
 - 优化插件分类名称，将原有 “对话” 更名为 “对话&作图”