### PR TITLE
添加通义千问在线模型系列支持&增加插件

### DIFF
--- a/config.py
+++ b/config.py
@@ -92,8 +92,9 @@ AVAIL_LLM_MODELS = ["gpt-3.5-turbo-1106","gpt-4-1106-preview","gpt-4-vision-prev
                     "api2d-gpt-3.5-turbo", 'api2d-gpt-3.5-turbo-16k',
                     "gpt-4", "gpt-4-32k", "azure-gpt-4", "api2d-gpt-4",
                     "chatglm3", "moss", "claude-2"]
-# P.S. 其他可用的模型还包括 ["zhipuai", "qianfan", "deepseekcoder", "llama2", "qwen", "gpt-3.5-turbo-0613", "gpt-3.5-turbo-16k-0613",  "gpt-3.5-random"
-# "spark", "sparkv2", "sparkv3", "chatglm_onnx", "claude-1-100k", "claude-2", "internlm", "jittorllms_pangualpha", "jittorllms_llama"]
+# P.S. 其他可用的模型还包括 ["zhipuai", "qianfan", "deepseekcoder", "llama2", "qwen-local", "gpt-3.5-turbo-0613", "gpt-3.5-turbo-16k-0613",  "gpt-3.5-random"
+# "spark", "sparkv2", "sparkv3", "chatglm_onnx", "claude-1-100k", "claude-2", "internlm", "jittorllms_pangualpha", "jittorllms_llama"
+# “qwen-turbo", "qwen-plus", "qwen-max"]
 
 
 # 定义界面上“询问多个GPT模型”插件应该使用哪些模型，请从AVAIL_LLM_MODELS中选择，并在不同模型之间用`&`间隔，例如"gpt-3.5-turbo&chatglm3&azure-gpt-4"
@@ -103,7 +104,11 @@ MULTI_QUERY_LLM_MODELS = "gpt-3.5-turbo&chatglm3"
 # 选择本地模型变体（只有当AVAIL_LLM_MODELS包含了对应本地模型时，才会起作用）
 # 如果你选择Qwen系列的模型，那么请在下面的QWEN_MODEL_SELECTION中指定具体的模型
 # 也可以是具体的模型路径
-QWEN_MODEL_SELECTION = "Qwen/Qwen-1_8B-Chat-Int8"
+QWEN_LOCAL_MODEL_SELECTION = "Qwen/Qwen-1_8B-Chat-Int8"
+
+
+# 接入通义千问在线大模型 https://dashscope.console.aliyun.com/
+DASHSCOPE_API_KEY = "此处填阿里灵积云API秘钥" # 阿里灵积云API_KEY
 
 
 # 百度千帆（LLM_MODEL="qianfan"）
@@ -284,6 +289,9 @@ NUM_CUSTOM_BASIC_BTN = 4
 │   ├── ZHIPUAI_API_KEY
 │   └── ZHIPUAI_MODEL
 │
+├── "qwen-turbo" 等通义千问大模型
+│   └──  DASHSCOPE_API_KEY
+│
 └── "newbing" Newbing接口不再稳定，不推荐使用
     ├── NEWBING_STYLE
     └── NEWBING_COOKIES
@@ -300,7 +308,7 @@ NUM_CUSTOM_BASIC_BTN = 4
 ├── "jittorllms_pangualpha"
 ├── "jittorllms_llama"
 ├── "deepseekcoder"
-├── "qwen"
+├── "qwen-local"
 ├──  RWKV的支持见Wiki
 └── "llama2"
 

--- a/config.py
+++ b/config.py
@@ -108,7 +108,7 @@ QWEN_LOCAL_MODEL_SELECTION = "Qwen/Qwen-1_8B-Chat-Int8"
 
 
 # 接入通义千问在线大模型 https://dashscope.console.aliyun.com/
-DASHSCOPE_API_KEY = "此处填阿里灵积云API秘钥" # 阿里灵积云API_KEY
+DASHSCOPE_API_KEY = "" # 阿里灵积云API_KEY
 
 
 # 百度千帆（LLM_MODEL="qianfan"）

--- a/crazy_functions/crazy_utils.py
+++ b/crazy_functions/crazy_utils.py
@@ -139,6 +139,8 @@ def can_multi_process(llm):
     if llm.startswith('gpt-'): return True
     if llm.startswith('api2d-'): return True
     if llm.startswith('azure-'): return True
+    if llm.startswith('spark'): return True
+    if llm.startswith('zhipuai'): return True
     return False
 
 def request_gpt_model_multi_threads_with_very_awesome_ui_and_high_efficiency(

--- a/main.py
+++ b/main.py
@@ -292,7 +292,9 @@ def main():
             cancel_handles.append(click_handle)
         # 文件上传区，接收文件后与chatbot的互动
         file_upload.upload(on_file_uploaded, [file_upload, chatbot, txt, txt2, checkboxes, cookies], [chatbot, txt, txt2, cookies])
+        file_upload.upload(None, None, None,   _js=r"()=>{toast_push('上传完毕, 请等待文件清单展现后继续操作 ...'); cancel_loading_status();}")
         file_upload_2.upload(on_file_uploaded, [file_upload_2, chatbot, txt, txt2, checkboxes, cookies], [chatbot, txt, txt2, cookies])
+        file_upload_2.upload(None, None, None, _js=r"()=>{toast_push('上传完毕, 请等待文件清单展现后继续操作 ...'); cancel_loading_status();}")
         # 函数插件-固定按钮区
         for k in plugins:
             if not plugins[k].get("AsButton", True): continue

--- a/main.py
+++ b/main.py
@@ -291,10 +291,8 @@ def main():
             click_handle = btn.click(fn=ArgsGeneralWrapper(predict), inputs=[*input_combo, gr.State(True), gr.State(btn.value)], outputs=output_combo)
             cancel_handles.append(click_handle)
         # 文件上传区，接收文件后与chatbot的互动
-        file_upload.upload(on_file_uploaded, [file_upload, chatbot, txt, txt2, checkboxes, cookies], [chatbot, txt, txt2, cookies])
-        file_upload.upload(None, None, None,   _js=r"()=>{toast_push('上传完毕, 请等待文件清单展现后继续操作 ...'); cancel_loading_status();}")
-        file_upload_2.upload(on_file_uploaded, [file_upload_2, chatbot, txt, txt2, checkboxes, cookies], [chatbot, txt, txt2, cookies])
-        file_upload_2.upload(None, None, None, _js=r"()=>{toast_push('上传完毕, 请等待文件清单展现后继续操作 ...'); cancel_loading_status();}")
+        file_upload.upload(on_file_uploaded, [file_upload, chatbot, txt, txt2, checkboxes, cookies], [chatbot, txt, txt2, cookies]).then(None, None, None,   _js=r"()=>{toast_push('上传完毕 ...'); cancel_loading_status();}")
+        file_upload_2.upload(on_file_uploaded, [file_upload_2, chatbot, txt, txt2, checkboxes, cookies], [chatbot, txt, txt2, cookies]).then(None, None, None, _js=r"()=>{toast_push('上传完毕 ...'); cancel_loading_status();}")
         # 函数插件-固定按钮区
         for k in plugins:
             if not plugins[k].get("AsButton", True): continue

--- a/request_llms/bridge_all.py
+++ b/request_llms/bridge_all.py
@@ -431,16 +431,48 @@ if "chatglm_onnx" in AVAIL_LLM_MODELS:
         })
     except:
         print(trimmed_format_exc())
-if "qwen" in AVAIL_LLM_MODELS:
+if "qwen-local" in AVAIL_LLM_MODELS:
+    try:
+        from .bridge_qwen_local import predict_no_ui_long_connection as qwen_local_noui
+        from .bridge_qwen_local import predict as qwen_local_ui
+        model_info.update({
+            "qwen-local": {
+                "fn_with_ui": qwen_local_ui,
+                "fn_without_ui": qwen_local_noui,
+                "endpoint": None,
+                "max_token": 4096,
+                "tokenizer": tokenizer_gpt35,
+                "token_cnt": get_token_num_gpt35,
+            }
+        })
+    except:
+        print(trimmed_format_exc())
+if "qwen-turbo" in AVAIL_LLM_MODELS or "qwen-plus" in AVAIL_LLM_MODELS or "qwen-max" in AVAIL_LLM_MODELS:   # zhipuai
     try:
         from .bridge_qwen import predict_no_ui_long_connection as qwen_noui
         from .bridge_qwen import predict as qwen_ui
         model_info.update({
-            "qwen": {
+            "qwen-turbo": {
                 "fn_with_ui": qwen_ui,
                 "fn_without_ui": qwen_noui,
                 "endpoint": None,
-                "max_token": 4096,
+                "max_token": 6144,
+                "tokenizer": tokenizer_gpt35,
+                "token_cnt": get_token_num_gpt35,
+            },
+            "qwen-plus": {
+                "fn_with_ui": qwen_ui,
+                "fn_without_ui": qwen_noui,
+                "endpoint": None,
+                "max_token": 30720,
+                "tokenizer": tokenizer_gpt35,
+                "token_cnt": get_token_num_gpt35,
+            },
+            "qwen-max": {
+                "fn_with_ui": qwen_ui,
+                "fn_without_ui": qwen_noui,
+                "endpoint": None,
+                "max_token": 28672,
                 "tokenizer": tokenizer_gpt35,
                 "token_cnt": get_token_num_gpt35,
             }

--- a/request_llms/bridge_qwen.py
+++ b/request_llms/bridge_qwen.py
@@ -5,16 +5,6 @@ from toolbox import check_packages, report_exception
 
 model_name = 'Qwen'
 
-def validate_key():
-    DASHSCOPE_API_KEY = get_conf("DASHSCOPE_API_KEY")
-    if DASHSCOPE_API_KEY == '': return False
-    return True
-
-if not validate_key():
-    raise RuntimeError('请配置DASHSCOPE_API_KEY')
-os.environ['DASHSCOPE_API_KEY'] = get_conf("DASHSCOPE_API_KEY")
-
-
 def predict_no_ui_long_connection(inputs, llm_kwargs, history=[], sys_prompt="", observe_window=[], console_slience=False):
     """
         ⭐多线程方法
@@ -45,6 +35,12 @@ def predict(inputs, llm_kwargs, plugin_kwargs, chatbot, history=[], system_promp
         check_packages(["dashscope"])
     except:
         yield from update_ui_lastest_msg(f"导入软件依赖失败。使用该模型需要额外依赖，安装方法```pip install --upgrade dashscope```。",
+                                         chatbot=chatbot, history=history, delay=0)
+        return
+
+    # 检查DASHSCOPE_API_KEY
+    if get_conf("DASHSCOPE_API_KEY") == "":
+        yield from update_ui_lastest_msg(f"请配置 DASHSCOPE_API_KEY。",
                                          chatbot=chatbot, history=history, delay=0)
         return
 

--- a/request_llms/bridge_qwen_local.py
+++ b/request_llms/bridge_qwen_local.py
@@ -1,0 +1,59 @@
+model_name = "Qwen_local"
+cmd_to_install = "`pip install -r request_llms/requirements_qwen_local.txt`"
+
+from toolbox import ProxyNetworkActivate, get_conf
+from .local_llm_class import LocalLLMHandle, get_local_llm_predict_fns
+
+
+
+# ------------------------------------------------------------------------------------------------------------------------
+# 🔌💻 Local Model
+# ------------------------------------------------------------------------------------------------------------------------
+class GetQwenLMHandle(LocalLLMHandle):
+
+    def load_model_info(self):
+        # 🏃‍♂️🏃‍♂️🏃‍♂️ 子进程执行
+        self.model_name = model_name
+        self.cmd_to_install = cmd_to_install
+
+    def load_model_and_tokenizer(self):
+        # 🏃‍♂️🏃‍♂️🏃‍♂️ 子进程执行
+        # from modelscope import AutoModelForCausalLM, AutoTokenizer, GenerationConfig
+        from transformers import AutoModelForCausalLM, AutoTokenizer
+        from transformers.generation import GenerationConfig
+        with ProxyNetworkActivate('Download_LLM'):
+            model_id = get_conf('QWEN_LOCAL_MODEL_SELECTION')
+            self._tokenizer = AutoTokenizer.from_pretrained(model_id, trust_remote_code=True, resume_download=True)
+            # use fp16
+            model = AutoModelForCausalLM.from_pretrained(model_id, device_map="auto", trust_remote_code=True).eval()
+            model.generation_config = GenerationConfig.from_pretrained(model_id, trust_remote_code=True)  # 可指定不同的生成长度、top_p等相关超参
+            self._model = model
+
+        return self._model, self._tokenizer
+
+    def llm_stream_generator(self, **kwargs):
+        # 🏃‍♂️🏃‍♂️🏃‍♂️ 子进程执行
+        def adaptor(kwargs):
+            query = kwargs['query']
+            max_length = kwargs['max_length']
+            top_p = kwargs['top_p']
+            temperature = kwargs['temperature']
+            history = kwargs['history']
+            return query, max_length, top_p, temperature, history
+
+        query, max_length, top_p, temperature, history = adaptor(kwargs)
+
+        for response in self._model.chat_stream(self._tokenizer, query, history=history):
+            yield response
+        
+    def try_to_import_special_deps(self, **kwargs):
+        # import something that will raise error if the user does not install requirement_*.txt
+        # 🏃‍♂️🏃‍♂️🏃‍♂️ 主进程执行
+        import importlib
+        importlib.import_module('modelscope')
+
+
+# ------------------------------------------------------------------------------------------------------------------------
+# 🔌💻 GPT-Academic Interface
+# ------------------------------------------------------------------------------------------------------------------------
+predict_no_ui_long_connection, predict = get_local_llm_predict_fns(GetQwenLMHandle, model_name)

--- a/request_llms/bridge_qwen_local.py
+++ b/request_llms/bridge_qwen_local.py
@@ -1,4 +1,4 @@
-model_name = "Qwen_local"
+model_name = "Qwen_Local"
 cmd_to_install = "`pip install -r request_llms/requirements_qwen_local.txt`"
 
 from toolbox import ProxyNetworkActivate, get_conf

--- a/request_llms/bridge_spark.py
+++ b/request_llms/bridge_spark.py
@@ -26,7 +26,7 @@ def predict_no_ui_long_connection(inputs, llm_kwargs, history=[], sys_prompt="",
 
     from .com_sparkapi import SparkRequestInstance
     sri = SparkRequestInstance()
-    for response in sri.generate(inputs, llm_kwargs, history, sys_prompt):
+    for response in sri.generate(inputs, llm_kwargs, history, sys_prompt, use_image_api=False):
         if len(observe_window) >= 1:
             observe_window[0] = response
         if len(observe_window) >= 2:
@@ -52,7 +52,7 @@ def predict(inputs, llm_kwargs, plugin_kwargs, chatbot, history=[], system_promp
     # 开始接收回复    
     from .com_sparkapi import SparkRequestInstance
     sri = SparkRequestInstance()
-    for response in sri.generate(inputs, llm_kwargs, history, system_prompt):
+    for response in sri.generate(inputs, llm_kwargs, history, system_prompt, use_image_api=True):
         chatbot[-1] = (inputs, response)
         yield from update_ui(chatbot=chatbot, history=history)
 

--- a/request_llms/com_qwenapi.py
+++ b/request_llms/com_qwenapi.py
@@ -7,11 +7,20 @@ timeout_bot_msg = '[Local Message] Request timeout. Network error.'
 
 class QwenRequestInstance():
     def __init__(self):
-
+        import dashscope
         self.time_to_yield_event = threading.Event()
         self.time_to_exit_event = threading.Event()
-
         self.result_buf = ""
+
+        def validate_key():
+            DASHSCOPE_API_KEY = get_conf("DASHSCOPE_API_KEY")
+            if DASHSCOPE_API_KEY == '': return False
+            return True
+
+        if not validate_key():
+            raise RuntimeError('请配置 DASHSCOPE_API_KEY')
+        dashscope.api_key = get_conf("DASHSCOPE_API_KEY")
+
 
     def generate(self, inputs, llm_kwargs, history, system_prompt):
         # import _thread as thread

--- a/request_llms/com_qwenapi.py
+++ b/request_llms/com_qwenapi.py
@@ -1,0 +1,85 @@
+from http import HTTPStatus
+from toolbox import get_conf
+import threading
+import logging
+
+timeout_bot_msg = '[Local Message] Request timeout. Network error.'
+
+class QwenRequestInstance():
+    def __init__(self):
+
+        self.time_to_yield_event = threading.Event()
+        self.time_to_exit_event = threading.Event()
+
+        self.result_buf = ""
+
+    def generate(self, inputs, llm_kwargs, history, system_prompt):
+        # import _thread as thread
+        from dashscope import Generation
+        QWEN_MODEL = {
+            'qwen-turbo': Generation.Models.qwen_turbo,
+            'qwen-plus': Generation.Models.qwen_plus,
+            'qwen-max': Generation.Models.qwen_max,
+        }[llm_kwargs['llm_model']]
+        top_p = llm_kwargs.get('top_p', 0.8)
+        if top_p == 0: top_p += 1e-5
+        if top_p == 1: top_p -= 1e-5
+
+        self.result_buf = ""
+        responses = Generation.call(
+            model=QWEN_MODEL,
+            messages=generate_message_payload(inputs, llm_kwargs, history, system_prompt),
+            top_p=top_p,
+            temperature=llm_kwargs.get('temperature', 1.0),
+            result_format='message',
+            stream=True,
+            incremental_output=True
+        )
+
+        for response in responses:
+            if response.status_code == HTTPStatus.OK:
+                if response.output.choices[0].finish_reason == 'stop':
+                    yield self.result_buf
+                    break
+                elif response.output.choices[0].finish_reason == 'length':
+                    self.result_buf += "[Local Message] 生成长度过长，后续输出被截断"
+                    yield self.result_buf
+                    break
+                else:
+                    self.result_buf += response.output.choices[0].message.content
+                    yield self.result_buf
+            else:
+                self.result_buf += f"[Local Message] 请求错误：状态码：{response.status_code}，错误码:{response.code}，消息：{response.message}"
+                yield self.result_buf
+                break
+        logging.info(f'[raw_input] {inputs}')
+        logging.info(f'[response] {self.result_buf}')
+        return self.result_buf
+
+
+def generate_message_payload(inputs, llm_kwargs, history, system_prompt):
+    conversation_cnt = len(history) // 2
+    if system_prompt == '': system_prompt = 'Hello!'
+    messages = [{"role": "user", "content": system_prompt}, {"role": "assistant", "content": "Certainly!"}]
+    if conversation_cnt:
+        for index in range(0, 2*conversation_cnt, 2):
+            what_i_have_asked = {}
+            what_i_have_asked["role"] = "user"
+            what_i_have_asked["content"] = history[index]
+            what_gpt_answer = {}
+            what_gpt_answer["role"] = "assistant"
+            what_gpt_answer["content"] = history[index+1]
+            if what_i_have_asked["content"] != "":
+                if what_gpt_answer["content"] == "":
+                    continue
+                if what_gpt_answer["content"] == timeout_bot_msg:
+                    continue
+                messages.append(what_i_have_asked)
+                messages.append(what_gpt_answer)
+            else:
+                messages[-1]['content'] = what_gpt_answer['content']
+    what_i_ask_now = {}
+    what_i_ask_now["role"] = "user"
+    what_i_ask_now["content"] = inputs
+    messages.append(what_i_ask_now)
+    return messages

--- a/request_llms/requirements_qwen.txt
+++ b/request_llms/requirements_qwen.txt
@@ -1,4 +1,1 @@
-modelscope
-transformers_stream_generator
-auto-gptq
-optimum
+dashscope

--- a/request_llms/requirements_qwen_local.txt
+++ b/request_llms/requirements_qwen_local.txt
@@ -1,0 +1,4 @@
+modelscope
+transformers_stream_generator
+auto-gptq
+optimum

--- a/request_llms/requirements_qwen_local.txt
+++ b/request_llms/requirements_qwen_local.txt
@@ -2,3 +2,4 @@ modelscope
 transformers_stream_generator
 auto-gptq
 optimum
+urllib3<2

--- a/tests/test_llms.py
+++ b/tests/test_llms.py
@@ -18,7 +18,7 @@ if __name__ == "__main__":
     # from request_llms.bridge_internlm import predict_no_ui_long_connection
     # from request_llms.bridge_deepseekcoder import predict_no_ui_long_connection
     # from request_llms.bridge_qwen_7B import predict_no_ui_long_connection
-    from request_llms.bridge_qwen import predict_no_ui_long_connection
+    from request_llms.bridge_qwen_local import predict_no_ui_long_connection
     # from request_llms.bridge_spark import predict_no_ui_long_connection
     # from request_llms.bridge_zhipu import predict_no_ui_long_connection
     # from request_llms.bridge_chatglm3 import predict_no_ui_long_connection

--- a/themes/common.js
+++ b/themes/common.js
@@ -1,3 +1,7 @@
+// -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+//  第 1 部分: 工具函数
+// -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+
 function gradioApp() {
     // https://github.com/GaiZhenbiao/ChuanhuChatGPT/tree/main/web_assets/javascript
     const elems = document.getElementsByTagName('gradio-app');
@@ -36,6 +40,51 @@ function getCookie(name) {
 
     return null;
 }
+
+let toastCount = 0;
+function toast_push(msg, duration) {
+    duration = isNaN(duration) ? 3000 : duration;
+    const existingToasts = document.querySelectorAll('.toast');
+    existingToasts.forEach(toast => {
+        toast.style.top = `${parseInt(toast.style.top, 10) - 70}px`;
+    });
+    const m = document.createElement('div');
+    m.innerHTML = msg;
+    m.classList.add('toast');
+    m.style.cssText = `font-size: var(--text-md) !important; color: rgb(255, 255, 255); background-color: rgba(0, 0, 0, 0.6); padding: 10px 15px; border-radius: 4px; position: fixed; top: ${50 + toastCount * 70}%; left: 50%; transform: translateX(-50%); width: auto; text-align: center; transition: top 0.3s;`;
+    document.body.appendChild(m);
+    setTimeout(function () {
+        m.style.opacity = '0';
+        setTimeout(function () {
+            document.body.removeChild(m);
+            toastCount--;
+        }, 500);
+    }, duration);
+    toastCount++;
+}
+
+function toast_up(msg) {
+    var m = document.getElementById('toast_up');
+    if (m) {
+        document.body.removeChild(m); // remove the loader from the body
+    }
+    m = document.createElement('div');
+    m.id = 'toast_up';
+    m.innerHTML = msg;
+    m.style.cssText = "font-size: var(--text-md) !important; color: rgb(255, 255, 255); background-color: rgba(0, 0, 100, 0.6); padding: 10px 15px; margin: 0 0 0 -60px; border-radius: 4px; position: fixed; top: 50%; left: 50%; width: auto; text-align: center;";
+    document.body.appendChild(m);
+}
+function toast_down() {
+    var m = document.getElementById('toast_up');
+    if (m) {
+        document.body.removeChild(m); // remove the loader from the body
+    }
+}
+
+
+// -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+//  第 2 部分: 复制按钮
+// -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
 
 function addCopyButton(botElement) {
     // https://github.com/GaiZhenbiao/ChuanhuChatGPT/tree/main/web_assets/javascript
@@ -98,6 +147,12 @@ function chatbotContentChanged(attempt = 1, force = false) {
     }
 }
 
+
+
+// -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+//  第 3 部分: chatbot动态高度调整
+// -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+
 function chatbotAutoHeight() {
     // 自动调整高度
     function update_height() {
@@ -127,8 +182,6 @@ function chatbotAutoHeight() {
     }, 50); // 每100毫秒执行一次
 }
 
-
-
 function get_elements(consider_state_panel = false) {
     var chatbot = document.querySelector('#gpt-chatbot > div.wrap.svelte-18telvq');
     if (!chatbot) {
@@ -153,6 +206,18 @@ function get_elements(consider_state_panel = false) {
     return { panel_height_target, chatbot_height, chatbot };
 }
 
+
+
+// -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+//  第 4 部分: 粘贴、拖拽文件上传
+// -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+
+var elem_upload = null;
+var elem_upload_float = null;
+var elem_input_main = null;
+var elem_input_float = null;
+var elem_chatbot = null;
+var exist_file_msg = '⚠️请先删除上传区（左上方）中的历史文件，再尝试上传。'
 
 function add_func_paste(input) {
     let paste_files = [];
@@ -182,20 +247,21 @@ function add_func_paste(input) {
 
 function add_func_drag(elem) {
     if (elem) {
-        const dragEvents = ["dragover", "dragenter"];
+        const dragEvents = ["dragover"];
         const leaveEvents = ["dragleave", "dragend", "drop"];
 
         const onDrag = function (e) {
             e.preventDefault();
             e.stopPropagation();
             if (elem_upload_float.querySelector("input[type=file]")) {
-                toast_push('释放以上传文件', 50)
+                toast_up('⚠️释放以上传文件')
             } else {
-                toast_push('⚠️请先删除上传区中的历史文件，再尝试上传。', 50)
+                toast_up(exist_file_msg)
             }
         };
 
         const onLeave = function (e) {
+            toast_down();
             e.preventDefault();
             e.stopPropagation();
         };
@@ -237,35 +303,11 @@ async function upload_files(files) {
             Object.defineProperty(event, "currentTarget", { value: uploadInputElement, enumerable: true });
             Object.defineProperty(uploadInputElement, "files", { value: files, enumerable: true });
             uploadInputElement.dispatchEvent(event);
-
-            // toast_push('🎉上传文件成功', 2000)
         } else {
-            toast_push('⚠️请先删除上传区中的历史文件，再尝试上传。', 3000)
+            toast_push(exist_file_msg, 3000)
         }
     }
 }
-//提示信息 封装
-function toast_push(msg, duration) {
-    duration = isNaN(duration) ? 3000 : duration;
-    const m = document.createElement('div');
-    m.innerHTML = msg;
-    m.style.cssText = "font-size:  var(--text-md) !important; color: rgb(255, 255, 255);background-color: rgba(0, 0, 0, 0.6);padding: 10px 15px;margin: 0 0 0 -60px;border-radius: 4px;position: fixed;    top: 50%;left: 50%;width: auto; text-align: center;";
-    document.body.appendChild(m);
-    setTimeout(function () {
-        var d = 0.5;
-        m.style.opacity = '0';
-        setTimeout(function () {
-            document.body.removeChild(m)
-        }, d * 1000);
-    }, duration);
-}
-
-var elem_upload = null;
-var elem_upload_float = null;
-var elem_input_main = null;
-var elem_input_float = null;
-var gptChatbot = null;
-
 
 function begin_loading_status() {
     // Create the loader div and add styling
@@ -293,6 +335,7 @@ function begin_loading_status() {
     }`;
     document.head.appendChild(styleSheet);
 }
+
 function cancel_loading_status() {
     var loadingElement = document.getElementById('Js_File_Loading');
     if (loadingElement) {
@@ -311,6 +354,7 @@ function cancel_loading_status() {
         });
     }
 }
+
 function register_upload_event() {
     elem_upload_float = document.getElementById('elem_upload_float')
     const upload_component = elem_upload_float.querySelector("input[type=file]");
@@ -321,6 +365,7 @@ function register_upload_event() {
         });
     }
 }
+
 function monitoring_input_box() {
     register_upload_event();
 
@@ -328,6 +373,7 @@ function monitoring_input_box() {
     elem_upload_float = document.getElementById('elem_upload_float')
     elem_input_main = document.getElementById('user_input_main')
     elem_input_float = document.getElementById('user_input_float')
+    elem_chatbot = document.getElementById('gpt-chatbot')
 
     if (elem_input_main) {
         if (elem_input_main.querySelector("textarea")) {
@@ -339,9 +385,8 @@ function monitoring_input_box() {
             add_func_paste(elem_input_float.querySelector("textarea"))
         }
     }
-    gptChatbot = document.getElementById('gpt-chatbot')
-    if (gptChatbot) {
-        add_func_drag(gptChatbot)
+    if (elem_chatbot) {
+        add_func_drag(elem_chatbot)
     }
 }
 
@@ -351,6 +396,14 @@ window.addEventListener("DOMContentLoaded", function () {
     // const ga = document.getElementsByTagName("gradio-app");
     gradioApp().addEventListener("render", monitoring_input_box);
 });
+
+
+
+
+
+// -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+//  第 5 部分: 音频按钮样式变化
+// -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
 
 function audio_fn_init() {
     let audio_component = document.getElementById('elem_audio');
@@ -387,6 +440,13 @@ function audio_fn_init() {
 
     }
 }
+
+
+
+
+// -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+//  第 6 部分: JS初始化函数
+// -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
 
 function GptAcademicJavaScriptInit(LAYOUT = "LEFT-RIGHT") {
     audio_fn_init();

--- a/themes/common.js
+++ b/themes/common.js
@@ -3,7 +3,7 @@ function gradioApp() {
     const elems = document.getElementsByTagName('gradio-app');
     const elem = elems.length == 0 ? document : elems[0];
     if (elem !== document) {
-        elem.getElementById = function(id) {
+        elem.getElementById = function (id) {
             return document.getElementById(id);
         };
     }
@@ -12,31 +12,31 @@ function gradioApp() {
 
 function setCookie(name, value, days) {
     var expires = "";
-  
+
     if (days) {
-      var date = new Date();
-      date.setTime(date.getTime() + (days * 24 * 60 * 60 * 1000));
-      expires = "; expires=" + date.toUTCString();
+        var date = new Date();
+        date.setTime(date.getTime() + (days * 24 * 60 * 60 * 1000));
+        expires = "; expires=" + date.toUTCString();
     }
-  
+
     document.cookie = name + "=" + value + expires + "; path=/";
 }
 
 function getCookie(name) {
     var decodedCookie = decodeURIComponent(document.cookie);
     var cookies = decodedCookie.split(';');
-  
+
     for (var i = 0; i < cookies.length; i++) {
-      var cookie = cookies[i].trim();
-  
-      if (cookie.indexOf(name + "=") === 0) {
-        return cookie.substring(name.length + 1, cookie.length);
-      }
+        var cookie = cookies[i].trim();
+
+        if (cookie.indexOf(name + "=") === 0) {
+            return cookie.substring(name.length + 1, cookie.length);
+        }
     }
-  
+
     return null;
-  }
-  
+}
+
 function addCopyButton(botElement) {
     // https://github.com/GaiZhenbiao/ChuanhuChatGPT/tree/main/web_assets/javascript
     // Copy bot button
@@ -49,7 +49,7 @@ function addCopyButton(botElement) {
         // messageBtnColumnElement.remove();
         return;
     }
-    
+
     var copyButton = document.createElement('button');
     copyButton.classList.add('copy-bot-btn');
     copyButton.setAttribute('aria-label', 'Copy');
@@ -98,40 +98,38 @@ function chatbotContentChanged(attempt = 1, force = false) {
     }
 }
 
-function chatbotAutoHeight(){
+function chatbotAutoHeight() {
     // 自动调整高度
-    function update_height(){
+    function update_height() {
         var { panel_height_target, chatbot_height, chatbot } = get_elements(true);
-        if (panel_height_target!=chatbot_height)
-        {
+        if (panel_height_target != chatbot_height) {
             var pixelString = panel_height_target.toString() + 'px';
-            chatbot.style.maxHeight = pixelString; chatbot.style.height = pixelString; 
+            chatbot.style.maxHeight = pixelString; chatbot.style.height = pixelString;
         }
     }
 
-    function update_height_slow(){
+    function update_height_slow() {
         var { panel_height_target, chatbot_height, chatbot } = get_elements();
-        if (panel_height_target!=chatbot_height)
-        {
-            new_panel_height = (panel_height_target - chatbot_height)*0.5 + chatbot_height;
-            if (Math.abs(new_panel_height - panel_height_target) < 10){
+        if (panel_height_target != chatbot_height) {
+            new_panel_height = (panel_height_target - chatbot_height) * 0.5 + chatbot_height;
+            if (Math.abs(new_panel_height - panel_height_target) < 10) {
                 new_panel_height = panel_height_target;
             }
             // console.log(chatbot_height, panel_height_target, new_panel_height);
             var pixelString = new_panel_height.toString() + 'px';
-            chatbot.style.maxHeight = pixelString; chatbot.style.height = pixelString; 
+            chatbot.style.maxHeight = pixelString; chatbot.style.height = pixelString;
         }
     }
     monitoring_input_box()
     update_height();
-    setInterval(function() {
+    setInterval(function () {
         update_height_slow()
     }, 50); // 每100毫秒执行一次
 }
 
 
 
-function get_elements(consider_state_panel=false) {
+function get_elements(consider_state_panel = false) {
     var chatbot = document.querySelector('#gpt-chatbot > div.wrap.svelte-18telvq');
     if (!chatbot) {
         chatbot = document.querySelector('#gpt-chatbot');
@@ -142,13 +140,13 @@ function get_elements(consider_state_panel=false) {
     // const panel4 = document.querySelector('#interact-panel').getBoundingClientRect();
     const panel5 = document.querySelector('#input-panel2').getBoundingClientRect();
     const panel_active = document.querySelector('#state-panel').getBoundingClientRect();
-    if (consider_state_panel || panel_active.height < 25){
+    if (consider_state_panel || panel_active.height < 25) {
         document.state_panel_height = panel_active.height;
     }
     // 25 是chatbot的label高度, 16 是右侧的gap
-    var panel_height_target = panel1.height + panel2.height + panel3.height + 0 + 0 - 25 + 16*2;
+    var panel_height_target = panel1.height + panel2.height + panel3.height + 0 + 0 - 25 + 16 * 2;
     // 禁止动态的state-panel高度影响
-    panel_height_target = panel_height_target + (document.state_panel_height-panel_active.height)
+    panel_height_target = panel_height_target + (document.state_panel_height - panel_active.height)
     var panel_height_target = parseInt(panel_height_target);
     var chatbot_height = chatbot.style.height;
     var chatbot_height = parseInt(chatbot_height);
@@ -173,7 +171,7 @@ function add_func_paste(input) {
                 }
                 if (paste_files.length > 0) {
                     // 按照文件列表执行批量上传逻辑
-                    await paste_upload_files(paste_files);
+                    await upload_files(paste_files);
                     paste_files = []
 
                 }
@@ -182,8 +180,42 @@ function add_func_paste(input) {
     }
 }
 
+function add_func_drag(elem) {
+    if (elem) {
+        const dragEvents = ["dragover", "dragenter"];
+        const leaveEvents = ["dragleave", "dragend", "drop"];
 
-async function paste_upload_files(files) {
+        const onDrag = function (e) {
+            e.preventDefault();
+            e.stopPropagation();
+            if (elem_upload_float.querySelector("input[type=file]")) {
+                toast_push('释放以上传文件', 50)
+            } else {
+                toast_push('⚠️请先删除上传区中的历史文件，再尝试上传。', 50)
+            }
+        };
+
+        const onLeave = function (e) {
+            e.preventDefault();
+            e.stopPropagation();
+        };
+
+        dragEvents.forEach(event => {
+            elem.addEventListener(event, onDrag);
+        });
+
+        leaveEvents.forEach(event => {
+            elem.addEventListener(event, onLeave);
+        });
+
+        elem.addEventListener("drop", async function (e) {
+            const files = e.dataTransfer.files;
+            await upload_files(files);
+        });
+    }
+}
+
+async function upload_files(files) {
     const uploadInputElement = elem_upload_float.querySelector("input[type=file]");
     let totalSizeMb = 0
     if (files && files.length > 0) {
@@ -195,19 +227,20 @@ async function paste_upload_files(files) {
             }
             // 检查文件总大小是否超过20MB
             if (totalSizeMb > 20) {
-                toast_push('⚠️文件夹大于20MB 🚀上传文件中', 2000)
+                toast_push('⚠️文件夹大于 20MB 🚀上传文件中', 3000)
                 // return;  // 如果超过了指定大小, 可以不进行后续上传操作
             }
-             // 监听change事件， 原生Gradio可以实现
+            // 监听change事件， 原生Gradio可以实现
             // uploadInputElement.addEventListener('change', function(){replace_input_string()});
             let event = new Event("change");
-            Object.defineProperty(event, "target", {value: uploadInputElement, enumerable: true});
-            Object.defineProperty(event, "currentTarget", {value: uploadInputElement, enumerable: true});
-            Object.defineProperty(uploadInputElement, "files", {value: files, enumerable: true});
+            Object.defineProperty(event, "target", { value: uploadInputElement, enumerable: true });
+            Object.defineProperty(event, "currentTarget", { value: uploadInputElement, enumerable: true });
+            Object.defineProperty(uploadInputElement, "files", { value: files, enumerable: true });
             uploadInputElement.dispatchEvent(event);
+
             // toast_push('🎉上传文件成功', 2000)
         } else {
-            toast_push('⚠️请先删除上传区中的历史文件，再尝试粘贴。', 2000)
+            toast_push('⚠️请先删除上传区中的历史文件，再尝试上传。', 3000)
         }
     }
 }
@@ -231,22 +264,84 @@ var elem_upload = null;
 var elem_upload_float = null;
 var elem_input_main = null;
 var elem_input_float = null;
+var gptChatbot = null;
 
 
+function begin_loading_status() {
+    // Create the loader div and add styling
+    var loader = document.createElement('div');
+    loader.id = 'Js_File_Loading';
+    loader.style.position = "absolute";
+    loader.style.top = "50%";
+    loader.style.left = "50%";
+    loader.style.width = "60px";
+    loader.style.height = "60px";
+    loader.style.border = "16px solid #f3f3f3";
+    loader.style.borderTop = "16px solid #3498db";
+    loader.style.borderRadius = "50%";
+    loader.style.animation = "spin 2s linear infinite";
+    loader.style.transform = "translate(-50%, -50%)";
+    document.body.appendChild(loader); // Add the loader to the body
+    // Set the CSS animation keyframes
+    var styleSheet = document.createElement('style');
+    // styleSheet.type = 'text/css';
+    styleSheet.id = 'Js_File_Loading_Style'
+    styleSheet.innerText = `
+    @keyframes spin {
+        0% { transform: rotate(0deg); }
+        100% { transform: rotate(360deg); }
+    }`;
+    document.head.appendChild(styleSheet);
+}
+function cancel_loading_status() {
+    var loadingElement = document.getElementById('Js_File_Loading');
+    if (loadingElement) {
+        document.body.removeChild(loadingElement); // remove the loader from the body
+    }
+    var loadingStyle = document.getElementById('Js_File_Loading_Style');
+    if (loadingStyle) {
+        document.head.removeChild(loadingStyle);
+    }
+    let clearButton = document.querySelectorAll('div[id*="elem_upload"] button[aria-label="Clear"]');
+    for (let button of clearButton) {
+        button.addEventListener('click', function () {
+            setTimeout(function () {
+                register_upload_event();
+            }, 50);
+        });
+    }
+}
+function register_upload_event() {
+    elem_upload_float = document.getElementById('elem_upload_float')
+    const upload_component = elem_upload_float.querySelector("input[type=file]");
+    if (upload_component) {
+        upload_component.addEventListener('change', function (event) {
+            toast_push('正在上传中，请稍等。', 2000);
+            begin_loading_status();
+        });
+    }
+}
 function monitoring_input_box() {
+    register_upload_event();
+
     elem_upload = document.getElementById('elem_upload')
     elem_upload_float = document.getElementById('elem_upload_float')
     elem_input_main = document.getElementById('user_input_main')
     elem_input_float = document.getElementById('user_input_float')
+
     if (elem_input_main) {
         if (elem_input_main.querySelector("textarea")) {
             add_func_paste(elem_input_main.querySelector("textarea"))
         }
     }
     if (elem_input_float) {
-        if (elem_input_float.querySelector("textarea")){
+        if (elem_input_float.querySelector("textarea")) {
             add_func_paste(elem_input_float.querySelector("textarea"))
         }
+    }
+    gptChatbot = document.getElementById('gpt-chatbot')
+    if (gptChatbot) {
+        add_func_drag(gptChatbot)
     }
 }
 
@@ -259,13 +354,13 @@ window.addEventListener("DOMContentLoaded", function () {
 
 function audio_fn_init() {
     let audio_component = document.getElementById('elem_audio');
-    if (audio_component){
+    if (audio_component) {
         let buttonElement = audio_component.querySelector('button');
         let specificElement = audio_component.querySelector('.hide.sr-only');
         specificElement.remove();
 
         buttonElement.childNodes[1].nodeValue = '启动麦克风';
-        buttonElement.addEventListener('click', function(event) {
+        buttonElement.addEventListener('click', function (event) {
             event.stopPropagation();
             toast_push('您启动了麦克风!下一步请点击“实时语音对话”启动语音对话。');
         });
@@ -273,14 +368,14 @@ function audio_fn_init() {
         // 查找语音插件按钮
         let buttons = document.querySelectorAll('button');
         let audio_button = null;
-        for(let button of buttons){
-            if (button.textContent.includes('语音')){
+        for (let button of buttons) {
+            if (button.textContent.includes('语音')) {
                 audio_button = button;
                 break;
             }
         }
-        if (audio_button){
-            audio_button.addEventListener('click', function() {
+        if (audio_button) {
+            audio_button.addEventListener('click', function () {
                 toast_push('您点击了“实时语音对话”启动语音对话。');
             });
             let parent_element = audio_component.parentElement; // 将buttonElement移动到audio_button的内部
@@ -300,5 +395,5 @@ function GptAcademicJavaScriptInit(LAYOUT = "LEFT-RIGHT") {
         chatbotContentChanged(1);
     });
     chatbotObserver.observe(chatbotIndicator, { attributes: true, childList: true, subtree: true });
-    if (LAYOUT === "LEFT-RIGHT") {chatbotAutoHeight();}
+    if (LAYOUT === "LEFT-RIGHT") { chatbotAutoHeight(); }
 }

--- a/themes/green.css
+++ b/themes/green.css
@@ -256,13 +256,13 @@ textarea.svelte-1pie7s6 {
     max-height: 95% !important;
     overflow-y: auto !important;
 }*/
-.app.svelte-1mya07g.svelte-1mya07g {
+/* .app.svelte-1mya07g.svelte-1mya07g {
     max-width: 100%;
     position: relative;
     padding: var(--size-4);
     width: 100%;
     height: 100%;
-}
+} */
 
 .gradio-container-3-32-2 h1 {
     font-weight: 700 !important;

--- a/toolbox.py
+++ b/toolbox.py
@@ -1129,7 +1129,7 @@ def get_user(chatbotwithcookies):
 
 class ProxyNetworkActivate():
     """
-    这段代码定义了一个名为TempProxy的空上下文管理器, 用于给一小段代码上代理
+    这段代码定义了一个名为ProxyNetworkActivate的空上下文管理器, 用于给一小段代码上代理
     """
     def __init__(self, task=None) -> None:
         self.task = task

--- a/version
+++ b/version
@@ -1,5 +1,5 @@
 {
-  "version": 3.63,
+  "version": 3.64,
   "show_feature": true,
-  "new_feature": "支持将图片粘贴到输入区 <-> 修复若干隐蔽的内存BUG <-> 修复多用户冲突问题 <-> 接入Deepseek Coder <-> AutoGen多智能体插件测试版"
+  "new_feature": "支持直接拖拽文件到上传区 <-> 支持将图片粘贴到输入区 <-> 修复若干隐蔽的内存BUG <-> 修复多用户冲突问题 <-> 接入Deepseek Coder <-> AutoGen多智能体插件测试版"
 }


### PR DESCRIPTION
- 增加了通义千问在线系列模型（qwen-max，qwen-plus，qwen-turbo）支持，目前通义千问max的api限时免费，是gpt3.5不错的平替。

- 在现有的批量总结PDF插件基础上略做修改，增加了两个总结PDF的插件“批量总结PDF_初步”和“批量总结Markdown文档_进阶”。拆分成两个插件的目的是可以用廉价的模型进行初步总结，随后用GPT-4进行最终提炼，提高经济性。

- 为精准翻译PDF(NOUGAT)插件增加了高级参数选项，另外增加了一个使用NOUGAT_API的版本，允许用户将gpt_academic服务和NOUGAT服务分开部署。API版本的插件也添加了高级参数支持，不过官方版本NOUGAT提供的API仅支持页码范围选择，若要支持更多参数请移步我的fork:https://github.com/leike0813/nougat
