### PR TITLE
修复分割函数中使用的变量错误

### DIFF
--- a/crazy_functions/crazy_utils.py
+++ b/crazy_functions/crazy_utils.py
@@ -466,6 +466,9 @@ def read_and_clean_pdf_text(fp):
                     return True
                 else:
                     return False
+            # 对于某些PDF会有第一个段落就以小写字母开头,为了避免索引错误直接返回
+            if starts_with_lowercase_word(meta_txt[0]):
+                return meta_txt
             for _ in range(100):
                 for index, block_txt in enumerate(meta_txt):
                     if starts_with_lowercase_word(block_txt):

--- a/crazy_functions/crazy_utils.py
+++ b/crazy_functions/crazy_utils.py
@@ -466,9 +466,9 @@ def read_and_clean_pdf_text(fp):
                     return True
                 else:
                     return False
-            # 对于某些PDF会有第一个段落就以小写字母开头,为了避免索引错误直接返回
+            # 对于某些PDF会有第一个段落就以小写字母开头,为了避免索引错误将其更改为大写
             if starts_with_lowercase_word(meta_txt[0]):
-                return meta_txt
+                meta_txt[0] = meta_txt[0].capitalize()
             for _ in range(100):
                 for index, block_txt in enumerate(meta_txt):
                     if starts_with_lowercase_word(block_txt):

--- a/crazy_functions/pdf_fns/breakdown_txt.py
+++ b/crazy_functions/pdf_fns/breakdown_txt.py
@@ -65,10 +65,10 @@ def cut(limit, get_token_fn, txt_tocut, must_break_at_empty_line, break_anyway=F
                 # 如果没有找到合适的切分点
                 if break_anyway:
                     # 是否允许暴力切分
-                    prev, post = force_breakdown(txt_tocut, limit, get_token_fn)
+                    prev, post = force_breakdown(remain_txt_to_cut, limit, get_token_fn)
                 else:
                     # 不允许直接报错
-                    raise RuntimeError(f"存在一行极长的文本！{txt_tocut}")
+                    raise RuntimeError(f"存在一行极长的文本！{remain_txt_to_cut}")
 
             # 追加列表
             res.append(prev); fin_len+=len(prev)


### PR DESCRIPTION
原有函数使用的变量txt_tocut处于while循环之外,在需要使用暴力分割时会导致无限重复分割而超时(表现为"正在文本切分"显示的%数会超过100%)