### PR TITLE
Update bridge_all.py

### DIFF
--- a/request_llms/bridge_all.py
+++ b/request_llms/bridge_all.py
@@ -498,22 +498,6 @@ if "qwen-turbo" in AVAIL_LLM_MODELS or "qwen-plus" in AVAIL_LLM_MODELS or "qwen-
         })
     except:
         print(trimmed_format_exc())
-if "chatgpt_website" in AVAIL_LLM_MODELS:   # 接入一些逆向工程https://github.com/acheong08/ChatGPT-to-API/
-    try:
-        from .bridge_chatgpt_website import predict_no_ui_long_connection as chatgpt_website_noui
-        from .bridge_chatgpt_website import predict as chatgpt_website_ui
-        model_info.update({
-            "chatgpt_website": {
-                "fn_with_ui": chatgpt_website_ui,
-                "fn_without_ui": chatgpt_website_noui,
-                "endpoint": openai_endpoint,
-                "max_token": 4096,
-                "tokenizer": tokenizer_gpt35,
-                "token_cnt": get_token_num_gpt35,
-            }
-        })
-    except:
-        print(trimmed_format_exc())
 if "spark" in AVAIL_LLM_MODELS:   # 讯飞星火认知大模型
     try:
         from .bridge_spark import predict_no_ui_long_connection as spark_noui


### PR DESCRIPTION
删除 "chatgpt_website" 函数，从而不再支持此类的基于逆向工程方法的接口，该方法对应的实现项目为：https://github.com/acheong08/ChatGPT-to-API/。目前，该项目已被开发者 archived，且该方法由于其实现的原理，而不可能是稳健和完美的，因此不是可持续维护的。

作为补充和替代，下面是一个可能更好的类似实现：
https://github.com/mufeng510/Free-ChatGPT-API

相关站点：
https://chat-shared.zhile.io/shared.html?v=2
https://chat-shared3.zhile.io/

pandoranext部署后的quota：
https://docs.pandoranext.com/api-reference/proxy#quota-consumption
https://docs.pandoranext.com/license/license_id

https://dash.pandoranext.com/
上面页面的显示的quota结果的说明：
follow 
https://github.com/wozulong
star 
https://github.com/pandora-next/deploy
各加500条quota。

下面的bug已经被官方修复，但是此网站列举的其他几个相关链接，应该还可以进行对应的操作：
https://ai-20240110.fakeopen.com/team