### PR TITLE
添加部分翻译

### DIFF
--- a/docs/translate_english.json
+++ b/docs/translate_english.json
@@ -3004,5 +3004,7 @@
     "1. 上传图片": "TranslatedText",
     "保存状态": "TranslatedText",
     "GPT-Academic对话存档": "TranslatedText",
-    "Arxiv论文精细翻译": "TranslatedText"
+    "Arxiv论文精细翻译": "TranslatedText",
+    "from crazy_functions.AdvancedFunctionTemplate import 测试图表渲染": "from crazy_functions.AdvancedFunctionTemplate import test_chart_rendering",
+    "测试图表渲染": "test_chart_rendering"
 }

--- a/docs/translate_std.json
+++ b/docs/translate_std.json
@@ -97,5 +97,12 @@
     "多智能体": "MultiAgent",
     "图片生成_DALLE2": "ImageGeneration_DALLE2",
     "图片生成_DALLE3": "ImageGeneration_DALLE3",
-    "图片修改_DALLE2": "ImageModification_DALLE2"
+    "图片修改_DALLE2": "ImageModification_DALLE2",
+    "生成多种Mermaid图表": "GenerateMultipleMermaidCharts",
+    "知识库文件注入": "InjectKnowledgeBaseFiles",
+    "PDF翻译中文并重新编译PDF": "TranslatePDFToChineseAndRecompilePDF",
+    "随机小游戏": "RandomMiniGame",
+    "互动小游戏": "InteractiveMiniGame",
+    "解析历史输入": "ParseHistoricalInput",
+    "高阶功能模板函数示意图": "HighOrderFunctionTemplateDiagram"
 }


### PR DESCRIPTION
避免了gpt(gpt-3.5-turbo-16k)总是将`测试图表渲染`翻译为`Test chart rendering`,导致函数缩进异常无法启动的错误