### PR TITLE
ADD_WAIFU = False的情况下禁用loadLive2D()函数

### DIFF
--- a/themes/common.py
+++ b/themes/common.py
@@ -15,4 +15,6 @@ def get_common_html_javascript_code():
             "file=themes/waifu_plugin/jquery-ui.min.js",
         ]:
             js += f"""<script src="{jsf}"></script>\n"""
+    else:
+        js += """<script>window.loadLive2D = function(){};</script>\n"""
     return js


### PR DESCRIPTION
ADD_WAIFU = False，浏览器会抛出错误：[Error] JQuery is not defined. 因为这时候没有jQuery库可用，却依然使用了loadLive2D()函数。现在加一个判断，如果ADD_WAIFU = False，禁用jQuery库的同时也禁用loadLive2D()函数，除非ADD_WAIFU = True