### PR TITLE
fix: 添加report_exception中缺失的a参数

### DIFF
--- a/crazy_functions/Latex输出PDF.py
+++ b/crazy_functions/Latex输出PDF.py
@@ -466,7 +466,7 @@ def PDF翻译中文并重新编译PDF(txt, llm_kwargs, plugin_kwargs, chatbot, h
             return True
         
         except:
-            report_exception(chatbot, history, b=f"发现重复上传，但是无法找到相关文件")
+            report_exception(chatbot, history, a=f"解析项目: {txt}", b=f"发现重复上传，但是无法找到相关文件")
             yield from update_ui(chatbot=chatbot, history=history)
             
             chatbot.append([f"没有相关文件", '尝试重新翻译PDF...'])


### PR DESCRIPTION
在report_exception函数的定义中，参数a未包含默认值，因此应提供相应的值传入。

https://github.com/binary-husky/gpt_academic/blob/160552cc5fcc16413db3dfa3176b3fb5ab613c5a/toolbox.py#L323-L328