### PR TITLE
Fix: openai project API key pattern

### DIFF
--- a/shared_utils/key_pattern_manager.py
+++ b/shared_utils/key_pattern_manager.py
@@ -14,7 +14,7 @@ def is_openai_api_key(key):
     if len(CUSTOM_API_KEY_PATTERN) != 0:
         API_MATCH_ORIGINAL = re.match(CUSTOM_API_KEY_PATTERN, key)
     else:
-        API_MATCH_ORIGINAL = re.match(r"sk-[a-zA-Z0-9]{48}$|sess-[a-zA-Z0-9]{40}$", key)
+        API_MATCH_ORIGINAL = re.match(r"sk-[a-zA-Z0-9]{48}$|sk-proj-[a-zA-Z0-9]{48}$|sess-[a-zA-Z0-9]{40}$", key)
     return bool(API_MATCH_ORIGINAL)
 
 


### PR DESCRIPTION
OpenAI has replaced User API keys with project API keys with a different key format and recommend using project-based API keys for more granular control over your resources (https://help.openai.com/en/articles/9186755-managing-your-work-in-the-api-platform-with-projects). This PR adds OpenAI new project API key patterns.