### PR TITLE
模仿临时key增加临时chatgpt格式api接入方法。在输入框输入如下json可以临时切换使用该api，页面刷新即失效。

### DIFF
--- a/toolbox.py
+++ b/toolbox.py
@@ -101,12 +101,16 @@ def ArgsGeneralWrapper(f):
         cookies.update({
             'top_p': top_p,
             'api_key': cookies['api_key'],
+            'tmp_model': cookies['tmp_model'],
+            'tmp_endpoint': cookies['tmp_endpoint'],
             'llm_model': llm_model,
             'temperature': temperature,
             'user_name': user_name,
         })
         llm_kwargs = {
             'api_key': cookies['api_key'],
+            'tmp_model': cookies['tmp_model'],
+            'tmp_endpoint': cookies['tmp_endpoint'],
             'llm_model': llm_model,
             'top_p': top_p,
             'max_length': max_length,
@@ -607,6 +611,8 @@ def load_chat_cookies():
         "api_key": API_KEY,
         "llm_model": LLM_MODEL,
         "customize_fn_overwrite": customize_fn_overwrite_,
+        "tmp_model":'',
+        "tmp_endpoint":'',
     }
 
 


### PR DESCRIPTION
和输入临时key一样，输入如下json{"api_key":"sk-heK1pbXG1JzHk84oBd03B2C1A1504587Ba8cEd40CbD2Bxxf","tmp_endpoint":"http://xxxx/v1/chat/completions","tmp_model":"gpt-3.5-turbo"}可以导入临时api。这样新的api不用重启程序可以使用。也可以用于测试one-api的渠道。