### PR TITLE
Docker build bug fix

### DIFF
--- a/docs/GithubAction+AllCapacity
+++ b/docs/GithubAction+AllCapacity
@@ -3,6 +3,9 @@
 # 从NVIDIA源，从而支持显卡（检查宿主的nvidia-smi中的cuda版本必须>=11.3）
 FROM fuqingxu/11.3.1-runtime-ubuntu20.04-with-texlive:latest
 
+# edge-tts需要的依赖，某些pip包所需的依赖
+RUN apt update && apt install ffmpeg build-essential -y
+
 # use python3 as the system default python
 WORKDIR /gpt
 RUN curl -sS https://bootstrap.pypa.io/get-pip.py | python3.8
@@ -28,8 +31,6 @@ RUN python3 -m pip install -r request_llms/requirements_chatglm.txt
 RUN python3 -m pip install -r request_llms/requirements_newbing.txt
 RUN python3 -m pip install nougat-ocr
 
-# edge-tts需要的依赖
-RUN apt update && apt install ffmpeg -y
 
 # 预热Tiktoken模块
 RUN python3  -c 'from check_proxy import warm_up_modules; warm_up_modules()'

--- a/docs/GithubAction+AllCapacityBeta
+++ b/docs/GithubAction+AllCapacityBeta
@@ -5,6 +5,9 @@
 # 从NVIDIA源，从而支持显卡（检查宿主的nvidia-smi中的cuda版本必须>=11.3）
 FROM fuqingxu/11.3.1-runtime-ubuntu20.04-with-texlive:latest
 
+# edge-tts需要的依赖，某些pip包所需的依赖
+RUN apt update && apt install ffmpeg build-essential -y
+
 # use python3 as the system default python
 WORKDIR /gpt
 RUN curl -sS https://bootstrap.pypa.io/get-pip.py | python3.8
@@ -36,8 +39,6 @@ RUN python3 -m pip install -r request_llms/requirements_chatglm.txt
 RUN python3 -m pip install -r request_llms/requirements_newbing.txt
 RUN python3 -m pip install nougat-ocr
 
-# edge-tts需要的依赖
-RUN apt update && apt install ffmpeg -y
 
 # 预热Tiktoken模块
 RUN python3  -c 'from check_proxy import warm_up_modules; warm_up_modules()'

--- a/docs/GithubAction+ChatGLM+Moss
+++ b/docs/GithubAction+ChatGLM+Moss
@@ -5,6 +5,8 @@ RUN apt-get update
 RUN apt-get install -y curl proxychains curl gcc
 RUN apt-get install -y git python python3 python-dev python3-dev --fix-missing
 
+# edge-tts需要的依赖，某些pip包所需的依赖
+RUN apt update && apt install ffmpeg build-essential -y
 
 # use python3 as the system default python
 RUN curl -sS https://bootstrap.pypa.io/get-pip.py | python3.8
@@ -21,8 +23,6 @@ RUN python3 -m pip install -r request_llms/requirements_qwen.txt
 RUN python3 -m pip install -r request_llms/requirements_chatglm.txt
 RUN python3 -m pip install -r request_llms/requirements_newbing.txt
 
-# edge-tts需要的依赖
-RUN apt update && apt install ffmpeg -y
 
 # 预热Tiktoken模块
 RUN python3  -c 'from check_proxy import warm_up_modules; warm_up_modules()'


### PR DESCRIPTION
镜像构建错误原因：由于上游pip包不再提供python3.8版本的whell，需要自行编译，但是源镜像中不带有`g++`编译器(由于Action读取的是master分支的构建文件，因此直接提交到master分支)

建议尽早更换python版本(3.8也太老了点吧)

添加依赖后测试构建成功：

![图片](https://github.com/binary-husky/gpt_academic/assets/122662527/5ec39557-0e7c-43bb-81bf-56a2a4ae32dd)

