### PR TITLE
Bug fix: Some non-standard forms of error return are not caught

### DIFF
--- a/request_llms/oai_std_model_template.py
+++ b/request_llms/oai_std_model_template.py
@@ -44,7 +44,8 @@ def decode_chunk(chunk):
     try:
         chunk = json.loads(chunk[6:])
     except:
-        finish_reason = "JSON_ERROR"
+        respose = "API_ERROR"
+        finish_reason = chunk
     # 错误处理部分
     if "error" in chunk:
         respose = "API_ERROR"


### PR DESCRIPTION
- 例如deepseek的金额不足错误返回

修改前(图片来自群反馈)：

![图片](https://github.com/binary-husky/gpt_academic/assets/122662527/a41b007d-baa3-4b60-ae1a-25b9c9cfc98f)

修改后：

![图片](https://github.com/binary-husky/gpt_academic/assets/122662527/2d9e9935-f1d9-4079-9192-fb2e79a341e7)
