### PR TITLE
修复 bug“重置”按钮报错

### DIFF
--- a/main.py
+++ b/main.py
@@ -226,8 +226,8 @@ def main():
         multiplex_sel.select(
             None, [multiplex_sel], None, _js=f"""(multiplex_sel)=>run_multiplex_shift(multiplex_sel)""")
         cancel_handles.append(submit_btn.click(**predict_args))
-        resetBtn.click(None, None, [chatbot, history, status], _js="""(a,b,c)=>reset_conversation(a,b,c)""")   # 先在前端快速清除chatbot&status
-        resetBtn2.click(None, None, [chatbot, history, status], _js="""(a,b,c)=>reset_conversation(a,b,c)""")  # 先在前端快速清除chatbot&status
+        resetBtn.click(None, None, [chatbot, history, status], _js="""(a,b,c)=>clear_conversation(a,b,c)""")   # 先在前端快速清除chatbot&status
+        resetBtn2.click(None, None, [chatbot, history, status], _js="""(a,b,c)=>clear_conversation(a,b,c)""")  # 先在前端快速清除chatbot&status
         # reset_server_side_args = (lambda history: ([], [], "已重置"), [history], [chatbot, history, status])
         # resetBtn.click(*reset_server_side_args)    # 再在后端清除history
         # resetBtn2.click(*reset_server_side_args)   # 再在后端清除history

--- a/main.py
+++ b/main.py
@@ -226,8 +226,8 @@ def main():
         multiplex_sel.select(
             None, [multiplex_sel], None, _js=f"""(multiplex_sel)=>run_multiplex_shift(multiplex_sel)""")
         cancel_handles.append(submit_btn.click(**predict_args))
-        resetBtn.click(None, None, [chatbot, history, status], _js="""(a,b,c)=>clear_conversation(a,b,c)""")   # 先在前端快速清除chatbot&status
-        resetBtn2.click(None, None, [chatbot, history, status], _js="""(a,b,c)=>clear_conversation(a,b,c)""")  # 先在前端快速清除chatbot&status
+        resetBtn.click(None, None, [chatbot, history, status], _js="""(a,b,c)=>reset_conversation(a,b,c)""")   # 先在前端快速清除chatbot&status
+        resetBtn2.click(None, None, [chatbot, history, status], _js="""(a,b,c)=>reset_conversation(a,b,c)""")  # 先在前端快速清除chatbot&status
         # reset_server_side_args = (lambda history: ([], [], "已重置"), [history], [chatbot, history, status])
         # resetBtn.click(*reset_server_side_args)    # 再在后端清除history
         # resetBtn2.click(*reset_server_side_args)   # 再在后端清除history

--- a/themes/common.js
+++ b/themes/common.js
@@ -1070,6 +1070,14 @@ function restore_chat_from_local_storage(event) {
 }
 
 
+function clear_conversation(a, b, c) {
+    update_conversation_metadata();
+    let stopButton = document.getElementById("elem_stop");
+    stopButton.click();
+    // console.log("clear_conversation");
+    return reset_conversation(a, b);
+}
+
 
 function reset_conversation(a, b) {
     // console.log("js_code_reset");


### PR DESCRIPTION
issue #2096 ，更新3.91版本后，点击重置按钮无响应。
检查console后发现clear_conversation无定义。
发现是函数定义的是reset_conversation。 