### PR TITLE
feat: 支持双栈访问

### DIFF
--- a/shared_utils/fastapi_server.py
+++ b/shared_utils/fastapi_server.py
@@ -275,7 +275,7 @@ def start_app(app_block, CONCURRENT_COUNT, AUTHENTICATION, PORT, SSL_KEYFILE, SS
     # --- --- uvicorn.Config --- ---
     ssl_keyfile = None if SSL_KEYFILE == "" else SSL_KEYFILE
     ssl_certfile = None if SSL_CERTFILE == "" else SSL_CERTFILE
-    server_name = "0.0.0.0"
+    server_name = None
     config = uvicorn.Config(
         fastapi_app,
         host=server_name,
@@ -286,7 +286,7 @@ def start_app(app_block, CONCURRENT_COUNT, AUTHENTICATION, PORT, SSL_KEYFILE, SS
         ssl_certfile=ssl_certfile,
     )
     server = Server(config)
-    url_host_name = "localhost" if server_name == "0.0.0.0" else server_name
+    url_host_name = "localhost" if server_name is None else server_name
     if ssl_keyfile is not None:
         if ssl_certfile is None:
             raise ValueError(


### PR DESCRIPTION
feat: set server_name to None to enable dual stack in web page

feat: #2064

实现双栈访问，ref to: https://github.com/encode/uvicorn/discussions/1529#discussioncomment-3061823

已经测试以下 host
- 0.0.0.0
- 127.0.0.1
- 192.168.38.197 (interface ip)
- [::0]
- [::1]
- localhost (hosts to localhost and [::1])

需要被进一步讨论

hosts file

```hosts
127.0.0.1               localhost
::1                     localhost
```