### PR TITLE
添加接入 火山引擎在线大模型 内容的支持

### DIFF
--- a/config.py
+++ b/config.py
@@ -43,7 +43,8 @@ AVAIL_LLM_MODELS = ["qwen-max", "o1-mini", "o1-mini-2024-09-12", "o1", "o1-2024-
                     "gpt-3.5-turbo-1106", "gpt-3.5-turbo-16k", "gpt-3.5-turbo", "azure-gpt-3.5",
                     "gpt-4", "gpt-4-32k", "azure-gpt-4", "glm-4", "glm-4v", "glm-3-turbo",
                     "gemini-1.5-pro", "chatglm3", "chatglm4",
-                    "deepseek-chat", "deepseek-coder", "deepseek-reasoner", "volcengine-deepseek-r1-250120",
+                    "deepseek-chat", "deepseek-coder", "deepseek-reasoner", 
+                    "volcengine-deepseek-r1-250120", "volcengine-deepseek-v3-241226",
                     ]
 
 EMBEDDING_MODEL = "text-embedding-3-small"

--- a/config.py
+++ b/config.py
@@ -43,7 +43,7 @@ AVAIL_LLM_MODELS = ["qwen-max", "o1-mini", "o1-mini-2024-09-12", "o1", "o1-2024-
                     "gpt-3.5-turbo-1106", "gpt-3.5-turbo-16k", "gpt-3.5-turbo", "azure-gpt-3.5",
                     "gpt-4", "gpt-4-32k", "azure-gpt-4", "glm-4", "glm-4v", "glm-3-turbo",
                     "gemini-1.5-pro", "chatglm3", "chatglm4",
-                    "deepseek-chat", "deepseek-coder", "deepseek-reasoner"
+                    "deepseek-chat", "deepseek-coder", "deepseek-reasoner", "volcengine-deepseek-r1-250120",
                     ]
 
 EMBEDDING_MODEL = "text-embedding-3-small"
@@ -265,6 +265,10 @@ MOONSHOT_API_KEY = ""
 
 # 零一万物(Yi Model) API KEY
 YIMODEL_API_KEY = ""
+
+
+# 接入火山引擎的在线大模型)，api-key获取地址 https://console.volcengine.com/ark/region:ark+cn-beijing/endpoint
+ARK_API_KEY = "00000000-0000-0000-0000-000000000000" # 火山引擎 API KEY
 
 
 # 紫东太初大模型 https://ai-maas.wair.ac.cn

--- a/tests/test_llms.py
+++ b/tests/test_llms.py
@@ -11,46 +11,65 @@ def validate_path():
 
 
 validate_path()  # validate path so you can run from base directory
+if __name__ == "__main__":
+    # from request_llms.bridge_taichu import predict_no_ui_long_connection
+    from request_llms.bridge_volcengine import predict_no_ui_long_connection
+    # from request_llms.bridge_cohere import predict_no_ui_long_connection
+    # from request_llms.bridge_spark import predict_no_ui_long_connection
+    # from request_llms.bridge_zhipu import predict_no_ui_long_connection
+    # from request_llms.bridge_chatglm3 import predict_no_ui_long_connection
+    llm_kwargs = {
+        "llm_model": "volcengine",
+        "max_length": 4096,
+        "top_p": 1,
+        "temperature": 1,
+    }
 
-if "在线模型":
-    if __name__ == "__main__":
-        from request_llms.bridge_taichu import predict_no_ui_long_connection
-        # from request_llms.bridge_cohere import predict_no_ui_long_connection
-        # from request_llms.bridge_spark import predict_no_ui_long_connection
-        # from request_llms.bridge_zhipu import predict_no_ui_long_connection
-        # from request_llms.bridge_chatglm3 import predict_no_ui_long_connection
-        llm_kwargs = {
-            "llm_model": "taichu",
-            "max_length": 4096,
-            "top_p": 1,
-            "temperature": 1,
-        }
+    result = predict_no_ui_long_connection(
+        inputs="请问什么是质子？", llm_kwargs=llm_kwargs, history=["你好", "我好！"], sys_prompt="系统"
+    )
+    print("final result:", result)
+    print("final result:", result)
+# if "在线模型":
+#     if __name__ == "__main__":
+#         # from request_llms.bridge_taichu import predict_no_ui_long_connection
+#         from request_llms.bridge_volcengine import predict_no_ui_long_connection
+#         # from request_llms.bridge_cohere import predict_no_ui_long_connection
+#         # from request_llms.bridge_spark import predict_no_ui_long_connection
+#         # from request_llms.bridge_zhipu import predict_no_ui_long_connection
+#         # from request_llms.bridge_chatglm3 import predict_no_ui_long_connection
+#         llm_kwargs = {
+#             "llm_model": "ep-20250222011816-5cq8z",
+#             "max_length": 4096,
+#             "top_p": 1,
+#             "temperature": 1,
+#         }
 
-        result = predict_no_ui_long_connection(
-            inputs="请问什么是质子？", llm_kwargs=llm_kwargs, history=["你好", "我好！"], sys_prompt="系统"
-        )
-        print("final result:", result)
-        print("final result:", result)
+#         result = predict_no_ui_long_connection(
+#             inputs="请问什么是质子？", llm_kwargs=llm_kwargs, history=["你好", "我好！"], sys_prompt="系统"
+#         )
+#         print("final result:", result)
+#         print("final result:", result)
 
 
-if "本地模型":
-    if __name__ == "__main__":
-        # from request_llms.bridge_newbingfree import predict_no_ui_long_connection
-        # from request_llms.bridge_moss import predict_no_ui_long_connection
-        # from request_llms.bridge_jittorllms_pangualpha import predict_no_ui_long_connection
-        # from request_llms.bridge_jittorllms_llama import predict_no_ui_long_connection
-        # from request_llms.bridge_claude import predict_no_ui_long_connection
-        # from request_llms.bridge_internlm import predict_no_ui_long_connection
-        # from request_llms.bridge_deepseekcoder import predict_no_ui_long_connection
-        # from request_llms.bridge_qwen_7B import predict_no_ui_long_connection
-        # from request_llms.bridge_qwen_local import predict_no_ui_long_connection
-        llm_kwargs = {
-            "max_length": 4096,
-            "top_p": 1,
-            "temperature": 1,
-        }
-        result = predict_no_ui_long_connection(
-            inputs="请问什么是质子？", llm_kwargs=llm_kwargs, history=["你好", "我好！"], sys_prompt=""
-        )
-        print("final result:", result)
+# if "本地模型":
+#     if __name__ == "__main__":
+#         # from request_llms.bridge_newbingfree import predict_no_ui_long_connection
+#         # from request_llms.bridge_moss import predict_no_ui_long_connection
+#         # from request_llms.bridge_jittorllms_pangualpha import predict_no_ui_long_connection
+#         # from request_llms.bridge_jittorllms_llama import predict_no_ui_long_connection
+#         # from request_llms.bridge_claude import predict_no_ui_long_connection
+#         # from request_llms.bridge_internlm import predict_no_ui_long_connection
+#         # from request_llms.bridge_deepseekcoder import predict_no_ui_long_connection
+#         # from request_llms.bridge_qwen_7B import predict_no_ui_long_connection
+#         # from request_llms.bridge_qwen_local import predict_no_ui_long_connection
+#         llm_kwargs = {
+#             "max_length": 4096,
+#             "top_p": 1,
+#             "temperature": 1,
+#         }
+#         result = predict_no_ui_long_connection(
+#             inputs="请问什么是质子？", llm_kwargs=llm_kwargs, history=["你好", "我好！"], sys_prompt=""
+#         )
+#         print("final result:", result)
 


### PR DESCRIPTION
通过
1.在config文件中增加ARK_API相关内容
2.增加request_llms\bridge_volcengine.py
3.修改request_llms\bridge_all.py，在其中添加# -=-=-=-=-=-=- 火山引擎大模型在线API -=-=-=-=-=-=-
内容，实现对火山引擎提供的大模型API接口的支持。
由于火山引擎提供的大模型API涉及API ID，特殊格式的API KEY，因此既有代码无法直接接入，故做出以上修改。