### PR TITLE
Migrate from pyautogen to ag2 Library

### DIFF
--- a/crazy_functions/多智能体.py
+++ b/crazy_functions/多智能体.py
@@ -59,7 +59,7 @@ def 多智能体终端(txt, llm_kwargs, plugin_kwargs, chatbot, history, system_
             import docker
     except:
         chatbot.append([ f"处理任务: {txt}",
-            f"导入软件依赖失败。使用该模块需要额外依赖，安装方法```pip install --upgrade pyautogen docker```。"])
+            f"导入软件依赖失败。使用该模块需要额外依赖，安装方法```pip install --upgrade ag2 docker```。"])
         yield from update_ui(chatbot=chatbot, history=history) # 刷新界面
         return
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ latex2mathml
 python-docx
 mdtex2html
 dashscope
-pyautogen
+ag2
 colorama
 Markdown
 pygments


### PR DESCRIPTION
Hey there! This is AG2 👋

First of all, thank you for using pyautogen! We've seen you're using pyautogen, and we're here to help you migrate to ag2.

This pull request is designed to help update this codebase by smoothly transitioning from the `pyautogen` library to the new `ag2` library.

Why the change? `pyautogen` is being deprecated, and `ag2` is now the recommended successor for ongoing development. 

The good news is, **there is no syntax difference between pyautogen and ag2** – this migration primarily involves updating library imports and usage.

This update will ensure the project stays compatible with the latest tools and can benefit from all the improvements in the ag2 ecosystem.

Could you please take a moment to review and merge this at your earliest convenience? Your collaboration is much appreciated! Thank you!
