### PR TITLE
feat: add MiniMax model support (MiniMax-M2.5 & MiniMax-M2.5-highspeed)

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Read this in [English](docs/README.English.md) | [日本語](docs/README.Japanes
 
 功能（⭐= 近期新增功能） | 描述
 --- | ---
-⭐[接入新模型](https://github.com/binary-husky/gpt_academic/wiki/%E5%A6%82%E4%BD%95%E5%88%87%E6%8D%A2%E6%A8%A1%E5%9E%8B) | 百度[千帆](https://cloud.baidu.com/doc/WENXINWORKSHOP/s/Nlks5zkzu)与文心一言, 通义千问[Qwen](https://modelscope.cn/models/qwen/Qwen-7B-Chat/summary)，上海AI-Lab[书生](https://github.com/InternLM/InternLM)，讯飞[星火](https://xinghuo.xfyun.cn/)，[LLaMa2](https://huggingface.co/meta-llama/Llama-2-7b-chat-hf)，[智谱GLM4](https://open.bigmodel.cn/)，DALLE3, [DeepseekCoder](https://coder.deepseek.com/)
+⭐[接入新模型](https://github.com/binary-husky/gpt_academic/wiki/%E5%A6%82%E4%BD%95%E5%88%87%E6%8D%A2%E6%A8%A1%E5%9E%8B) | 百度[千帆](https://cloud.baidu.com/doc/WENXINWORKSHOP/s/Nlks5zkzu)与文心一言, 通义千问[Qwen](https://modelscope.cn/models/qwen/Qwen-7B-Chat/summary)，上海AI-Lab[书生](https://github.com/InternLM/InternLM)，讯飞[星火](https://xinghuo.xfyun.cn/)，[LLaMa2](https://huggingface.co/meta-llama/Llama-2-7b-chat-hf)，[智谱GLM4](https://open.bigmodel.cn/)，DALLE3, [DeepseekCoder](https://coder.deepseek.com/)，[MiniMax](https://platform.minimaxi.com/)
 ⭐支持mermaid图像渲染 | 支持让GPT生成[流程图](https://www.bilibili.com/video/BV18c41147H9/)、状态转移图、甘特图、饼状图、GitGraph等等（3.7版本）
 ⭐Arxiv论文精细翻译 ([Docker](https://github.com/binary-husky/gpt_academic/pkgs/container/gpt_academic_with_latex)) | [插件] 一键[以超高质量翻译arxiv论文](https://www.bilibili.com/video/BV1dz4y1v77A/)，目前最好的论文翻译工具
 ⭐[实时语音对话输入](https://github.com/binary-husky/gpt_academic/blob/master/docs/use_audio.md) | [插件] 异步[监听音频](https://www.bilibili.com/video/BV1AV4y187Uy/)，自动断句，自动寻找回答时机

--- a/config.py
+++ b/config.py
@@ -66,6 +66,7 @@ EMBEDDING_MODEL = "text-embedding-3-small"
 #   "gemini-1.5-flash",
 #   "yi-34b-chat-0205","yi-34b-chat-200k","yi-large","yi-medium","yi-spark","yi-large-turbo","yi-large-preview",
 #   "grok-beta",
+#   "minimax-m2.5","minimax-m2.5-highspeed",
 # ]
 # --- --- --- ---
 # 此外，您还可以在接入one-api/vllm/ollama/Openroute时，
@@ -280,6 +281,9 @@ TAICHU_API_KEY = ""
 # Grok API KEY
 GROK_API_KEY = ""
 
+# MiniMax API KEY，获取地址 https://platform.minimaxi.com/
+MINIMAX_API_KEY = ""
+
 # Mathpix 拥有执行PDF的OCR功能，但是需要注册账号
 MATHPIX_APPID = ""
 MATHPIX_APPKEY = ""
@@ -425,6 +429,9 @@ ONE_API_KEY = "$API_KEY"
 │
 ├── "Gemini"
 │   └──  GEMINI_API_KEY
+│
+├── "minimax-m2.5", "minimax-m2.5-highspeed" MiniMax大模型
+│   └── MINIMAX_API_KEY
 │
 └── "one-api-...(max_token=...)" 用一种更方便的方式接入one-api多模型管理界面
     ├── AVAIL_LLM_MODELS

--- a/docs/models/overview.md
+++ b/docs/models/overview.md
@@ -26,6 +26,7 @@ GPT Academic 的核心优势之一是对多种大语言模型的广泛支持。�
 | 月之暗面 | `moonshot-v1-128k` | ⭐ | 超长上下文，适合长文档 |
 | 零一万物 | `yi-large`, `yi-medium` | ⭐ | 开源血统，性价比高 |
 | 火山引擎 | `volcengine-deepseek-r1` | ⭐ | DeepSeek 托管服务 |
+| MiniMax | `minimax-m2.5`, `minimax-m2.5-highspeed` | ⭐ | 国内直连，204K超长上下文 |
 
 ### 本地模型支持
 

--- a/request_llms/bridge_all.py
+++ b/request_llms/bridge_all.py
@@ -80,6 +80,7 @@ ollama_endpoint = "http://localhost:11434/api/chat"
 yimodel_endpoint = "https://api.lingyiwanwu.com/v1/chat/completions"
 deepseekapi_endpoint = "https://api.deepseek.com/v1/chat/completions"
 grok_model_endpoint = "https://api.x.ai/v1/chat/completions"
+minimax_endpoint = "https://api.minimax.io/v1/chat/completions"
 volcengine_endpoint = "https://ark.cn-beijing.volces.com/api/v3/chat/completions"
 
 if not AZURE_ENDPOINT.endswith('/'): AZURE_ENDPOINT += '/'
@@ -103,6 +104,7 @@ if ollama_endpoint in API_URL_REDIRECT: ollama_endpoint = API_URL_REDIRECT[ollam
 if yimodel_endpoint in API_URL_REDIRECT: yimodel_endpoint = API_URL_REDIRECT[yimodel_endpoint]
 if deepseekapi_endpoint in API_URL_REDIRECT: deepseekapi_endpoint = API_URL_REDIRECT[deepseekapi_endpoint]
 if grok_model_endpoint in API_URL_REDIRECT: grok_model_endpoint = API_URL_REDIRECT[grok_model_endpoint]
+if minimax_endpoint in API_URL_REDIRECT: minimax_endpoint = API_URL_REDIRECT[minimax_endpoint]
 if volcengine_endpoint in API_URL_REDIRECT: volcengine_endpoint = API_URL_REDIRECT[volcengine_endpoint]
 
 # 获取tokenizer
@@ -1233,6 +1235,36 @@ if any(item in claude_models for item in AVAIL_LLM_MODELS):
                 "tokenizer": tokenizer_gpt35,
                 "token_cnt": get_token_num_gpt35,
                 "enable_reasoning": True
+            },
+        })
+    except:
+        logger.error(trimmed_format_exc())
+
+# -=-=-=-=-=-=- MiniMax大模型在线API -=-=-=-=-=-=-
+minimax_models = ["minimax-m2.5", "minimax-m2.5-highspeed"]
+if any(item in minimax_models for item in AVAIL_LLM_MODELS):
+    try:
+        minimax_noui, minimax_ui = get_predict_function(
+            api_key_conf_name="MINIMAX_API_KEY", max_output_token=4096, disable_proxy=True
+        )
+        model_info.update({
+            "minimax-m2.5":{
+                "fn_with_ui": minimax_ui,
+                "fn_without_ui": minimax_noui,
+                "endpoint": minimax_endpoint,
+                "can_multi_thread": True,
+                "max_token": 204000,
+                "tokenizer": tokenizer_gpt35,
+                "token_cnt": get_token_num_gpt35,
+            },
+            "minimax-m2.5-highspeed":{
+                "fn_with_ui": minimax_ui,
+                "fn_without_ui": minimax_noui,
+                "endpoint": minimax_endpoint,
+                "can_multi_thread": True,
+                "max_token": 204000,
+                "tokenizer": tokenizer_gpt35,
+                "token_cnt": get_token_num_gpt35,
             },
         })
     except:


### PR DESCRIPTION
## Summary

Add [MiniMax](https://platform.minimax.io) as a new LLM provider in GPT Academic, supporting two models with 204K context window:

- **MiniMax-M2.5** — Peak performance, ultimate value
- **MiniMax-M2.5-highspeed** — Same performance, faster and more agile

MiniMax provides an OpenAI-compatible API, so no additional dependencies are needed — the existing `oai_std_model_template.py` handles everything.

## Changes

- **`config.py`**: Add `MINIMAX_API_KEY` configuration and model entries
- **`request_llms/bridge_all.py`**: Register MiniMax endpoint and models using `get_predict_function()`
- **`README.md`**: Add MiniMax to supported models feature table
- **`docs/models/overview.md`**: Add MiniMax to online models overview

## Usage

```python
# config_private.py
MINIMAX_API_KEY = "your-api-key"
LLM_MODEL = "minimax-m2.5"
AVAIL_LLM_MODELS = ["minimax-m2.5", "minimax-m2.5-highspeed"]
```

API keys can be obtained from https://platform.minimax.io

## API Documentation

- OpenAI Compatible Chat API: https://platform.minimax.io/docs/api-reference/text-openai-api

## Testing

- Verified both models respond correctly via streaming API
- Tested with `oai_std_model_template.py` compatible request format
- Both `minimax-m2.5` and `minimax-m2.5-highspeed` return valid streaming responses