### PR TITLE
fix: preserve custom LaTeX env shorthand macros during translation

### DIFF
--- a/crazy_functions/latex_fns/latex_actions.py
+++ b/crazy_functions/latex_fns/latex_actions.py
@@ -9,7 +9,7 @@ from crazy_functions.latex_fns.latex_toolbox import PRESERVE, TRANSFORM
 from crazy_functions.latex_fns.latex_toolbox import set_forbidden_text, set_forbidden_text_begin_end, set_forbidden_text_careful_brace
 from crazy_functions.latex_fns.latex_toolbox import reverse_forbidden_text_careful_brace, reverse_forbidden_text, convert_to_linklist, post_process
 from crazy_functions.latex_fns.latex_toolbox import fix_content, find_main_tex_file, merge_tex_files, compile_latex_with_timeout
-from crazy_functions.latex_fns.latex_toolbox import find_title_and_abs
+from crazy_functions.latex_fns.latex_toolbox import find_title_and_abs, extract_user_defined_env_patterns
 from crazy_functions.latex_fns.latex_pickle_io import objdump, objload
 
 
@@ -48,6 +48,10 @@ def split_subprocess(txt, project_folder, return_dict, opts):
     text, mask = set_forbidden_text(text, mask, [r"\\begin\{minipage\}(.*?)\\end\{minipage\}", r"\\begin\{minipage\*\}(.*?)\\end\{minipage\*\}"], re.DOTALL)
     text, mask = set_forbidden_text(text, mask, [r"\\begin\{align\*\}(.*?)\\end\{align\*\}", r"\\begin\{align\}(.*?)\\end\{align\}"], re.DOTALL)
     text, mask = set_forbidden_text(text, mask, [r"\\begin\{equation\}(.*?)\\end\{equation\}", r"\\begin\{equation\*\}(.*?)\\end\{equation\*\}"], re.DOTALL)
+    # 吸收用户自定义的环境简写命令 (如 \def\be{\begin{equation}} \def\ee{\end{equation}})
+    custom_env_patterns = extract_user_defined_env_patterns(text)
+    if custom_env_patterns:
+        text, mask = set_forbidden_text(text, mask, custom_env_patterns, re.DOTALL)
     text, mask = set_forbidden_text(text, mask, [r"\\includepdf\[(.*?)\]\{(.*?)\}", r"\\clearpage", r"\\newpage", r"\\appendix", r"\\tableofcontents", r"\\include\{(.*?)\}"])
     text, mask = set_forbidden_text(text, mask, [r"\\vspace\{(.*?)\}", r"\\hspace\{(.*?)\}", r"\\label\{(.*?)\}", r"\\begin\{(.*?)\}", r"\\end\{(.*?)\}", r"\\item "])
     text, mask = set_forbidden_text_careful_brace(text, mask, r"\\hl\{(.*?)\}", re.DOTALL)

--- a/crazy_functions/latex_fns/latex_toolbox.py
+++ b/crazy_functions/latex_fns/latex_toolbox.py
@@ -592,6 +592,41 @@ def fix_content(final_tex, node_string):
     return final_tex
 
 
+def extract_user_defined_env_patterns(text):
+    """
+    Detect user-defined shorthand commands for LaTeX environments, e.g.:
+        \\def\\be{\\begin{equation}}
+        \\def\\ee{\\end{equation}}
+    Returns a list of regex patterns that can be passed to set_forbidden_text
+    to preserve the corresponding environment blocks from GPT translation.
+    """
+    begin_defs = {}  # shorthand -> env_name
+    end_defs = {}    # shorthand -> env_name
+
+    # Match \\def\\cmd{\\begin{envname}}
+    for m in re.finditer(r'\\def\\([a-zA-Z]+)\s*\{\\begin\{([^}]+)\}\}', text):
+        begin_defs[m.group(1)] = m.group(2)
+    # Match \\def\\cmd{\\end{envname}}
+    for m in re.finditer(r'\\def\\([a-zA-Z]+)\s*\{\\end\{([^}]+)\}\}', text):
+        end_defs[m.group(1)] = m.group(2)
+
+    # Match \\newcommand{\\cmd}{\\begin{envname}} and \\renewcommand variants
+    for m in re.finditer(r'\\(?:newcommand|renewcommand)\{\\([a-zA-Z]+)\}\{\\begin\{([^}]+)\}\}', text):
+        begin_defs[m.group(1)] = m.group(2)
+    for m in re.finditer(r'\\(?:newcommand|renewcommand)\{\\([a-zA-Z]+)\}\{\\end\{([^}]+)\}\}', text):
+        end_defs[m.group(1)] = m.group(2)
+
+    patterns = []
+    for begin_cmd, env_name in begin_defs.items():
+        for end_cmd, end_env_name in end_defs.items():
+            if env_name == end_env_name:
+                # Use (?![a-zA-Z]) to avoid matching longer commands that start with the same prefix
+                # e.g., \be should not match \begin
+                patterns.append(rf'\\{begin_cmd}(?![a-zA-Z])(.*?)\\{end_cmd}(?![a-zA-Z])')
+                logger.info(f"Detected custom env shorthand: \\{begin_cmd}...\\{end_cmd} -> {{{env_name}}}")
+    return patterns
+
+
 def compile_latex_with_timeout(command, cwd, timeout=60):
     import subprocess
 


### PR DESCRIPTION
Fixes #2240

## Problem

Physics and math papers frequently define shorthand commands for equation environments using `\def` or `\newcommand`, e.g.:

```latex
\def\be{\begin{equation}}
\def\ee{\end{equation}}
\def\bea{\begin{eqnarray}}
\def\eea{\end{eqnarray}}
```

The LaTeX segmentation logic in `latex_actions.py` only recognized standard `\begin{equation}...\end{equation}` patterns. When authors used these shorthands, the enclosed math content was not preserved from GPT translation — causing it to be sent for translation (corrupting the math) or replaced with incorrect LaTeX delimiters like `\[`.

## Solution

Added `extract_user_defined_env_patterns()` in `latex_toolbox.py` that:

1. Scans the merged TeX content for `\def\cmd{\begin{envname}}` and `\def\cmd{\end{envname}}` declarations (also handles `\newcommand` / `\renewcommand`)
2. Finds matching begin/end pairs for the same environment name
3. Returns regex patterns for each matched pair with a negative lookahead `(?![a-zA-Z])` to avoid false matches on longer commands that share the same prefix (e.g., `\be` must not match `\begin`)

These patterns are then applied in `split_subprocess()` immediately after the standard equation/align patterns, so the custom shorthand blocks are correctly preserved from GPT translation.

## Testing

Manually tested with a synthetic TeX document containing `\def\be{\begin{equation}}` and `\def\ee{\end{equation}}`:

- `\be...\ee` blocks are correctly marked as PRESERVE
- `\begin{equation}` is NOT accidentally matched by the `\be` pattern (negative lookahead works)
- No changes to existing behavior when no custom shorthands are defined